### PR TITLE
task/#23

### DIFF
--- a/app/(notice)/[storeId]/notice-create.tsx
+++ b/app/(notice)/[storeId]/notice-create.tsx
@@ -1,90 +1,196 @@
-import { useState } from 'react';
+import { isAxiosError } from 'axios';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useEffect, useState } from 'react';
 import {
+  KeyboardAvoidingView,
+  Platform,
   Pressable,
   StyleSheet,
   TextInput,
   View,
 } from 'react-native';
 
+import {
+  createNotice,
+  getNotice,
+  updateNotice,
+} from '@/src/features/notice/api/notice';
+import {
+  buttonColorCta,
+  typoColorPrimary,
+} from '@/src/init/styles/tokens';
 import NText from '@/src/shared/ui/NText';
 import PageLayout from '@/src/shared/ui/PageLayout';
 
 export default function NoticeCreatePage() {
+  const router = useRouter();
+  const { storeId, noticeId } = useLocalSearchParams<{
+    storeId: string;
+    noticeId?: string;
+  }>();
+  const isEditMode = !!noticeId;
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [isPublic, setIsPublic] = useState(true);
+  const [loading, setLoading] = useState(isEditMode);
+  const [submitting, setSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const handleSubmit = () => {
-    console.log({
-      title,
-      content,
-      isPublic,
-    });
+  useEffect(() => {
+    if (!isEditMode || !storeId || !noticeId) {
+      return;
+    }
+
+    const fetchNotice = async () => {
+      try {
+        setLoading(true);
+        setErrorMessage(null);
+
+        const { data } = await getNotice(storeId, noticeId);
+        setTitle(data.title);
+        setContent(data.content ?? '');
+        setIsPublic(data.isPublic);
+      } catch {
+        setErrorMessage('수정할 공지를 불러오지 못했어요.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchNotice();
+  }, [isEditMode, noticeId, storeId]);
+
+  const handleSubmit = async () => {
+    const trimmedTitle = title.trim();
+    const trimmedContent = content.trim();
+
+    if (!storeId || submitting) {
+      return;
+    }
+
+    if (!trimmedTitle || !trimmedContent) {
+      setErrorMessage('제목과 공지 내용을 모두 입력해 주세요.');
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      setErrorMessage(null);
+
+      const data = {
+        title: trimmedTitle,
+        content: trimmedContent,
+        isPublic,
+      };
+
+      if (isEditMode && noticeId) {
+        await updateNotice(storeId, noticeId, data);
+      } else {
+        await createNotice(storeId, data);
+      }
+
+      router.back();
+    } catch (error) {
+      if (isAxiosError(error) && error.response?.status === 403) {
+        setErrorMessage(
+          isEditMode
+            ? '공지를 수정할 권한이 없어요.'
+            : '공지를 작성할 권한이 없어요.',
+        );
+      } else {
+        setErrorMessage(
+          isEditMode
+            ? '공지 수정 중 오류가 발생했어요.'
+            : '공지 작성 중 오류가 발생했어요.',
+        );
+      }
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
     <PageLayout
-      title="공지작성"
-    //   right={
-    //     <Pressable onPress={handleSubmit}>
-    //       <NText
-    //         variant="b14"
-    //         style={styles.submit}
-    //       >
-    //         등록
-    //       </NText>
-    //     </Pressable>
-    //   }
+      title={isEditMode ? '공지수정' : '공지작성'}
+      icon={
+        <NText variant="b16" style={styles.submit}>
+          {submitting
+            ? isEditMode
+              ? '수정 중'
+              : '등록 중'
+            : isEditMode
+              ? '수정'
+              : '등록'}
+        </NText>
+      }
+      onPressCheckIcon={handleSubmit}
     >
-      <View style={styles.container}>
-        <TextInput
-          placeholder="제목을 입력해주세요"
-          value={title}
-          onChangeText={setTitle}
-          style={styles.titleInput}
-        />
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={styles.container}
+      >
+        {loading ? (
+          <NText variant="r14">불러오는 중...</NText>
+        ) : (
+          <>
+            <View style={styles.form}>
+              <TextInput
+                placeholder="제목을 입력해주세요"
+                placeholderTextColor="#9A9A9A"
+                value={title}
+                onChangeText={setTitle}
+                editable={!submitting}
+                style={styles.titleInput}
+              />
 
-        <TextInput
-          placeholder="공지 내용을 입력해주세요"
-          value={content}
-          onChangeText={setContent}
-          multiline
-          textAlignVertical="top"
-          style={styles.contentInput}
-        />
+              <TextInput
+                placeholder="공지 내용을 입력해주세요"
+                placeholderTextColor="#9A9A9A"
+                value={content}
+                onChangeText={setContent}
+                editable={!submitting}
+                multiline
+                textAlignVertical="top"
+                style={styles.contentInput}
+              />
+            </View>
 
-        <View style={styles.settingContainer}>
-          <NText variant="m16">
-            공개 설정
+            <View style={styles.settingContainer}>
+              <NText variant="m16">공개 설정</NText>
+
+              <View style={styles.segment}>
+                <Pressable
+                  style={[
+                    styles.segmentButton,
+                    isPublic && styles.selected,
+                  ]}
+                  disabled={submitting}
+                  onPress={() => setIsPublic(true)}
+                >
+                  <NText variant="r14">공개</NText>
+                </Pressable>
+
+                <Pressable
+                  style={[
+                    styles.segmentButton,
+                    !isPublic && styles.selected,
+                  ]}
+                  disabled={submitting}
+                  onPress={() => setIsPublic(false)}
+                >
+                  <NText variant="r14">비공개</NText>
+                </Pressable>
+              </View>
+            </View>
+          </>
+        )}
+
+        {errorMessage && (
+          <NText variant="r12" style={styles.error}>
+            {errorMessage}
           </NText>
-
-          <View style={styles.segment}>
-            <Pressable
-              style={[
-                styles.segmentButton,
-                isPublic && styles.selected,
-              ]}
-              onPress={() => setIsPublic(true)}
-            >
-              <NText variant="r14">
-                공개
-              </NText>
-            </Pressable>
-
-            <Pressable
-              style={[
-                styles.segmentButton,
-                !isPublic && styles.selected,
-              ]}
-              onPress={() => setIsPublic(false)}
-            >
-              <NText variant="r14">
-                비공개
-              </NText>
-            </Pressable>
-          </View>
-        </View>
-      </View>
+        )}
+      </KeyboardAvoidingView>
     </PageLayout>
   );
 }
@@ -92,50 +198,66 @@ export default function NoticeCreatePage() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    gap: 16,
+    paddingTop: 32,
+    paddingBottom: 24,
   },
-
+  form: {
+    gap: 24,
+  },
   titleInput: {
-    height: 48,
-    backgroundColor: '#fff',
+    height: 68,
+    backgroundColor: '#FFFFFF',
     borderRadius: 12,
     paddingHorizontal: 16,
+    color: typoColorPrimary,
+    fontFamily: 'Pretendard',
+    fontSize: 16,
   },
-
   contentInput: {
-    flex: 1,
-    minHeight: 240,
-
-    backgroundColor: '#fff',
+    height: 220,
+    backgroundColor: '#FFFFFF',
     borderRadius: 12,
-
     padding: 16,
+    color: typoColorPrimary,
+    fontFamily: 'Pretendard',
+    fontSize: 16,
+    lineHeight: 24,
   },
-
   settingContainer: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
+    marginTop: 28,
   },
-
   segment: {
     flexDirection: 'row',
-    backgroundColor: '#F1F1F1',
-    borderRadius: 8,
+    backgroundColor: '#E9E9E9',
+    borderRadius: 12,
     padding: 2,
   },
-
   segmentButton: {
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-    borderRadius: 6,
+    minWidth: 72,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderRadius: 10,
+    alignItems: 'center',
   },
-
   selected: {
     backgroundColor: '#FFFFFF',
+    shadowColor: '#000000',
+    shadowOffset: {
+      width: 0,
+      height: 1,
+    },
+    shadowOpacity: 0.08,
+    shadowRadius: 3,
+    elevation: 2,
   },
-
   submit: {
-    color: '#5B57FF',
+    color: buttonColorCta,
+  },
+  error: {
+    marginTop: 12,
+    color: '#F64B3B',
   },
 });

--- a/app/(notice)/[storeId]/notice-create.tsx
+++ b/app/(notice)/[storeId]/notice-create.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react';
+import {
+  Pressable,
+  StyleSheet,
+  TextInput,
+  View,
+} from 'react-native';
+
+import NText from '@/src/shared/ui/NText';
+import PageLayout from '@/src/shared/ui/PageLayout';
+
+export default function NoticeCreatePage() {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [isPublic, setIsPublic] = useState(true);
+
+  const handleSubmit = () => {
+    console.log({
+      title,
+      content,
+      isPublic,
+    });
+  };
+
+  return (
+    <PageLayout
+      title="공지작성"
+    //   right={
+    //     <Pressable onPress={handleSubmit}>
+    //       <NText
+    //         variant="b14"
+    //         style={styles.submit}
+    //       >
+    //         등록
+    //       </NText>
+    //     </Pressable>
+    //   }
+    >
+      <View style={styles.container}>
+        <TextInput
+          placeholder="제목을 입력해주세요"
+          value={title}
+          onChangeText={setTitle}
+          style={styles.titleInput}
+        />
+
+        <TextInput
+          placeholder="공지 내용을 입력해주세요"
+          value={content}
+          onChangeText={setContent}
+          multiline
+          textAlignVertical="top"
+          style={styles.contentInput}
+        />
+
+        <View style={styles.settingContainer}>
+          <NText variant="m16">
+            공개 설정
+          </NText>
+
+          <View style={styles.segment}>
+            <Pressable
+              style={[
+                styles.segmentButton,
+                isPublic && styles.selected,
+              ]}
+              onPress={() => setIsPublic(true)}
+            >
+              <NText variant="r14">
+                공개
+              </NText>
+            </Pressable>
+
+            <Pressable
+              style={[
+                styles.segmentButton,
+                !isPublic && styles.selected,
+              ]}
+              onPress={() => setIsPublic(false)}
+            >
+              <NText variant="r14">
+                비공개
+              </NText>
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </PageLayout>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    gap: 16,
+  },
+
+  titleInput: {
+    height: 48,
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+  },
+
+  contentInput: {
+    flex: 1,
+    minHeight: 240,
+
+    backgroundColor: '#fff',
+    borderRadius: 12,
+
+    padding: 16,
+  },
+
+  settingContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+
+  segment: {
+    flexDirection: 'row',
+    backgroundColor: '#F1F1F1',
+    borderRadius: 8,
+    padding: 2,
+  },
+
+  segmentButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 6,
+  },
+
+  selected: {
+    backgroundColor: '#FFFFFF',
+  },
+
+  submit: {
+    color: '#5B57FF',
+  },
+});

--- a/app/(notice)/[storeId]/notice-create.tsx
+++ b/app/(notice)/[storeId]/notice-create.tsx
@@ -11,21 +11,29 @@ import {
   View,
 } from 'react-native';
 
+import { MemberRole } from '@/src/entities/member/member';
 import {
   createNotice,
   getNotice,
   updateNotice,
 } from '@/src/features/notice/api/notice';
+import useCurrentStoreAccess from '@/src/features/permission/lib/useCurrentStoreAccess';
 import {
   buttonColorCta,
   typoColorPrimary,
 } from '@/src/init/styles/tokens';
+import AccessDenied from '@/src/shared/ui/AccessDenied';
 import BaseModal from '@/src/shared/ui/BaseModal';
 import NText from '@/src/shared/ui/NText';
 import PageLayout from '@/src/shared/ui/PageLayout';
 
 export default function NoticeCreatePage() {
   const router = useRouter();
+  const access = useCurrentStoreAccess();
+  const canManageNotice =
+    access.isOwner ||
+    (access.role === MemberRole.MANAGER &&
+      !!access.permissions?.canManageNotice);
   const { storeId, noticeId } = useLocalSearchParams<{
     storeId: string;
     noticeId?: string;
@@ -45,7 +53,13 @@ export default function NoticeCreatePage() {
   });
 
   useEffect(() => {
-    if (!isEditMode || !storeId || !noticeId) {
+    if (
+      !access.loaded ||
+      !canManageNotice ||
+      !isEditMode ||
+      !storeId ||
+      !noticeId
+    ) {
       return;
     }
 
@@ -71,7 +85,7 @@ export default function NoticeCreatePage() {
     };
 
     fetchNotice();
-  }, [isEditMode, noticeId, storeId]);
+  }, [access.loaded, canManageNotice, isEditMode, noticeId, storeId]);
 
   const hasUnsavedChanges =
     title !== initialForm.title ||
@@ -155,6 +169,19 @@ export default function NoticeCreatePage() {
       setSubmitting(false);
     }
   };
+
+  if (!access.loaded) {
+    return <View />;
+  }
+
+  if (!canManageNotice) {
+    return (
+      <AccessDenied
+        title="공지를 관리할 수 없어요"
+        message="현재 매장 권한으로는 공지를 작성하거나 수정할 수 없어요"
+      />
+    );
+  }
 
   return (
     <PageLayout

--- a/app/(notice)/[storeId]/notice-create.tsx
+++ b/app/(notice)/[storeId]/notice-create.tsx
@@ -2,6 +2,7 @@ import { isAxiosError } from 'axios';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
 import {
+  BackHandler,
   KeyboardAvoidingView,
   Platform,
   Pressable,
@@ -19,6 +20,7 @@ import {
   buttonColorCta,
   typoColorPrimary,
 } from '@/src/init/styles/tokens';
+import BaseModal from '@/src/shared/ui/BaseModal';
 import NText from '@/src/shared/ui/NText';
 import PageLayout from '@/src/shared/ui/PageLayout';
 
@@ -35,6 +37,12 @@ export default function NoticeCreatePage() {
   const [loading, setLoading] = useState(isEditMode);
   const [submitting, setSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [exitModalVisible, setExitModalVisible] = useState(false);
+  const [initialForm, setInitialForm] = useState({
+    title: '',
+    content: '',
+    isPublic: true,
+  });
 
   useEffect(() => {
     if (!isEditMode || !storeId || !noticeId) {
@@ -50,6 +58,11 @@ export default function NoticeCreatePage() {
         setTitle(data.title);
         setContent(data.content ?? '');
         setIsPublic(data.isPublic);
+        setInitialForm({
+          title: data.title,
+          content: data.content ?? '',
+          isPublic: data.isPublic,
+        });
       } catch {
         setErrorMessage('수정할 공지를 불러오지 못했어요.');
       } finally {
@@ -59,6 +72,40 @@ export default function NoticeCreatePage() {
 
     fetchNotice();
   }, [isEditMode, noticeId, storeId]);
+
+  const hasUnsavedChanges =
+    title !== initialForm.title ||
+    content !== initialForm.content ||
+    isPublic !== initialForm.isPublic;
+
+  const handlePressBack = () => {
+    if (submitting) {
+      return;
+    }
+
+    if (hasUnsavedChanges) {
+      setExitModalVisible(true);
+      return;
+    }
+
+    router.back();
+  };
+
+  useEffect(() => {
+    const subscription = BackHandler.addEventListener(
+      'hardwareBackPress',
+      () => {
+        if (hasUnsavedChanges) {
+          setExitModalVisible(true);
+          return true;
+        }
+
+        return false;
+      },
+    );
+
+    return () => subscription.remove();
+  }, [hasUnsavedChanges]);
 
   const handleSubmit = async () => {
     const trimmedTitle = title.trim();
@@ -124,6 +171,7 @@ export default function NoticeCreatePage() {
         </NText>
       }
       onPressCheckIcon={handleSubmit}
+      onPressBack={handlePressBack}
     >
       <KeyboardAvoidingView
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
@@ -191,6 +239,33 @@ export default function NoticeCreatePage() {
           </NText>
         )}
       </KeyboardAvoidingView>
+
+      <BaseModal
+        visible={exitModalVisible}
+        onClose={() => setExitModalVisible(false)}
+      >
+        <BaseModal.Content>
+          <BaseModal.Title>
+            뒤로 가면 작성 중인 내용이 사라져요
+          </BaseModal.Title>
+        </BaseModal.Content>
+        <BaseModal.Actions>
+          <BaseModal.Button
+            variant="secondary"
+            onPress={() => setExitModalVisible(false)}
+          >
+            취소
+          </BaseModal.Button>
+          <BaseModal.Button
+            onPress={() => {
+              setExitModalVisible(false);
+              router.back();
+            }}
+          >
+            뒤로가기
+          </BaseModal.Button>
+        </BaseModal.Actions>
+      </BaseModal>
     </PageLayout>
   );
 }

--- a/app/(notice)/[storeId]/notice-detail.tsx
+++ b/app/(notice)/[storeId]/notice-detail.tsx
@@ -1,0 +1,52 @@
+import { StyleSheet, View } from 'react-native';
+
+import NText from '@/src/shared/ui/NText';
+import PageLayout from '@/src/shared/ui/PageLayout';
+
+export default function NoticeDetailPage() {
+  return (
+    <PageLayout title="공지">
+      <View style={styles.container}>
+        <NText variant="h2">
+          [필독] 이번 주말 야간 근무자 유의사항
+        </NText>
+
+        <View style={styles.metaContainer}>
+          <NText variant="r14">3월 11일 (수)</NText>
+          <NText variant="r14">이지현</NText>
+          <NText variant="r14">공개</NText>
+        </View>
+
+        <View style={styles.contentContainer}>
+          <NText variant="r14l">
+            매장 청소 구역이 일부 조정되었습니다.
+            창고 입구와 분리수거장 주변 청소 주기가 변경되었으니
+            새로운 리스트를 확인해 주세요.
+            {'\n\n'}
+            변경된 체크리스트는 가운데 열 게시판에도
+            부착되어 있습니다.
+            {'\n\n'}
+            모든 근무자는 교대시 해당 구역의 청결 상태를
+            상호 확인해 주시기 바랍니다.
+          </NText>
+        </View>
+      </View>
+    </PageLayout>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingTop: 16,
+  },
+
+  metaContainer: {
+    flexDirection: 'row',
+    gap: 12,
+    marginTop: 12,
+  },
+
+  contentContainer: {
+    marginTop: 32,
+  },
+});

--- a/app/(notice)/[storeId]/notice-detail.tsx
+++ b/app/(notice)/[storeId]/notice-detail.tsx
@@ -5,12 +5,14 @@ import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useCallback, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
 
+import { MemberRole } from '@/src/entities/member/member';
 import { Notice } from '@/src/entities/notice/notice';
 import {
   deleteNotice,
   getNotice,
   updateNotice,
 } from '@/src/features/notice/api/notice';
+import useCurrentStoreAccess from '@/src/features/permission/lib/useCurrentStoreAccess';
 import {
   typoColorPrimary,
   typoColorSecondary,
@@ -37,6 +39,13 @@ function formatNoticeDate(createdAt?: string) {
 
 export default function NoticeDetailPage() {
   const router = useRouter();
+  const access = useCurrentStoreAccess();
+  const canViewPrivateNotice =
+    access.isOwner || access.role === MemberRole.MANAGER;
+  const canManageNotice =
+    access.isOwner ||
+    (access.role === MemberRole.MANAGER &&
+      !!access.permissions?.canManageNotice);
   const { storeId, noticeId } = useLocalSearchParams<{
     storeId: string;
     noticeId: string;
@@ -76,7 +85,13 @@ export default function NoticeDetailPage() {
   );
 
   const handleToggleVisibility = async () => {
-    if (!notice || !storeId || !noticeId || updatingVisibility) {
+    if (
+      !canManageNotice ||
+      !notice ||
+      !storeId ||
+      !noticeId ||
+      updatingVisibility
+    ) {
       return;
     }
 
@@ -114,6 +129,10 @@ export default function NoticeDetailPage() {
   };
 
   const handlePressEdit = () => {
+    if (!canManageNotice) {
+      return;
+    }
+
     setMenuVisible(false);
     router.push({
       pathname: '/(notice)/[storeId]/notice-create',
@@ -122,7 +141,7 @@ export default function NoticeDetailPage() {
   };
 
   const handleDelete = async () => {
-    if (!storeId || !noticeId || deleting) {
+    if (!canManageNotice || !storeId || !noticeId || deleting) {
       return;
     }
 
@@ -152,22 +171,28 @@ export default function NoticeDetailPage() {
   const metaItems = [
     createdAt,
     notice?.authorName,
-    notice ? (notice.isPublic ? '공개' : '비공개') : '',
+    canViewPrivateNotice && notice
+      ? notice.isPublic
+        ? '공개'
+        : '비공개'
+      : '',
   ].filter(Boolean);
 
   return (
     <PageLayout
       title="공지사항"
       icon={
-        <Ionicons
-          name="ellipsis-vertical"
-          size={20}
-          color={typoColorPrimary}
-        />
+        canManageNotice ? (
+          <Ionicons
+            name="ellipsis-vertical"
+            size={20}
+            color={typoColorPrimary}
+          />
+        ) : undefined
       }
       onPressCheckIcon={() => setMenuVisible((visible) => !visible)}
     >
-      {menuVisible && (
+      {canManageNotice && menuVisible && (
         <>
           <Pressable
             style={styles.menuBackdrop}

--- a/app/(notice)/[storeId]/notice-detail.tsx
+++ b/app/(notice)/[storeId]/notice-detail.tsx
@@ -6,11 +6,16 @@ import { useCallback, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
 
 import { Notice } from '@/src/entities/notice/notice';
-import { getNotice, updateNotice } from '@/src/features/notice/api/notice';
+import {
+  deleteNotice,
+  getNotice,
+  updateNotice,
+} from '@/src/features/notice/api/notice';
 import {
   typoColorPrimary,
   typoColorSecondary,
 } from '@/src/init/styles/tokens';
+import BaseModal from '@/src/shared/ui/BaseModal';
 import NText from '@/src/shared/ui/NText';
 import PageLayout from '@/src/shared/ui/PageLayout';
 
@@ -41,6 +46,8 @@ export default function NoticeDetailPage() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [menuVisible, setMenuVisible] = useState(false);
   const [updatingVisibility, setUpdatingVisibility] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteModalVisible, setDeleteModalVisible] = useState(false);
 
   useFocusEffect(
     useCallback(() => {
@@ -114,6 +121,33 @@ export default function NoticeDetailPage() {
     });
   };
 
+  const handleDelete = async () => {
+    if (!storeId || !noticeId || deleting) {
+      return;
+    }
+
+    try {
+      setDeleting(true);
+      setErrorMessage(null);
+
+      await deleteNotice(storeId, noticeId);
+      setDeleteModalVisible(false);
+      setMenuVisible(false);
+      router.back();
+    } catch (error) {
+      setDeleteModalVisible(false);
+      setMenuVisible(false);
+
+      if (isAxiosError(error) && error.response?.status === 403) {
+        setErrorMessage('공지를 삭제할 권한이 없어요.');
+      } else {
+        setErrorMessage('공지 삭제 중 오류가 발생했어요.');
+      }
+    } finally {
+      setDeleting(false);
+    }
+  };
+
   const createdAt = formatNoticeDate(notice?.createdAt);
   const metaItems = [
     createdAt,
@@ -162,6 +196,19 @@ export default function NoticeDetailPage() {
                 수정
               </NText>
             </Pressable>
+
+            <Pressable
+              style={styles.menuItem}
+              disabled={deleting}
+              onPress={() => {
+                setMenuVisible(false);
+                setDeleteModalVisible(true);
+              }}
+            >
+              <NText variant="r14" style={styles.menuText}>
+                삭제하기
+              </NText>
+            </Pressable>
           </View>
         </>
       )}
@@ -201,6 +248,29 @@ export default function NoticeDetailPage() {
           </>
         )}
       </ScrollView>
+
+      <BaseModal
+        visible={deleteModalVisible}
+        onClose={() => setDeleteModalVisible(false)}
+      >
+        <BaseModal.Content>
+          <BaseModal.Title>공지를 삭제할까요?</BaseModal.Title>
+        </BaseModal.Content>
+        <BaseModal.Actions>
+          <BaseModal.Button
+            variant="secondary"
+            onPress={() => setDeleteModalVisible(false)}
+          >
+            취소
+          </BaseModal.Button>
+          <BaseModal.Button
+            disabled={deleting}
+            onPress={handleDelete}
+          >
+            {deleting ? '삭제 중' : '삭제'}
+          </BaseModal.Button>
+        </BaseModal.Actions>
+      </BaseModal>
     </PageLayout>
   );
 }

--- a/app/(notice)/[storeId]/notice-detail.tsx
+++ b/app/(notice)/[storeId]/notice-detail.tsx
@@ -1,10 +1,12 @@
 import { Ionicons } from '@expo/vector-icons';
-import { useLocalSearchParams } from 'expo-router';
-import { useEffect, useState } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
+import { isAxiosError } from 'axios';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useCallback, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
 
 import { Notice } from '@/src/entities/notice/notice';
-import { getNotice } from '@/src/features/notice/api/notice';
+import { getNotice, updateNotice } from '@/src/features/notice/api/notice';
 import {
   typoColorPrimary,
   typoColorSecondary,
@@ -29,6 +31,7 @@ function formatNoticeDate(createdAt?: string) {
 }
 
 export default function NoticeDetailPage() {
+  const router = useRouter();
   const { storeId, noticeId } = useLocalSearchParams<{
     storeId: string;
     noticeId: string;
@@ -37,30 +40,79 @@ export default function NoticeDetailPage() {
   const [loading, setLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [menuVisible, setMenuVisible] = useState(false);
+  const [updatingVisibility, setUpdatingVisibility] = useState(false);
 
-  useEffect(() => {
-    if (!storeId || !noticeId) {
-      setErrorMessage('공지 정보를 확인할 수 없어요.');
-      setLoading(false);
+  useFocusEffect(
+    useCallback(() => {
+      if (!storeId || !noticeId) {
+        setErrorMessage('공지 정보를 확인할 수 없어요.');
+        setLoading(false);
+        return;
+      }
+
+      const fetchNotice = async () => {
+        try {
+          setLoading(true);
+          setErrorMessage(null);
+
+          const { data } = await getNotice(storeId, noticeId);
+          setNotice(data);
+        } catch {
+          setErrorMessage('공지를 불러오지 못했어요.');
+        } finally {
+          setLoading(false);
+        }
+      };
+
+      fetchNotice();
+    }, [storeId, noticeId]),
+  );
+
+  const handleToggleVisibility = async () => {
+    if (!notice || !storeId || !noticeId || updatingVisibility) {
       return;
     }
 
-    const fetchNotice = async () => {
-      try {
-        setLoading(true);
-        setErrorMessage(null);
+    if (!notice.content?.trim()) {
+      setMenuVisible(false);
+      setErrorMessage('공지 내용이 없어 공개 상태를 변경할 수 없어요.');
+      return;
+    }
 
-        const { data } = await getNotice(storeId, noticeId);
-        setNotice(data);
-      } catch {
-        setErrorMessage('공지를 불러오지 못했어요.');
-      } finally {
-        setLoading(false);
+    try {
+      setUpdatingVisibility(true);
+      setErrorMessage(null);
+
+      await updateNotice(storeId, noticeId, {
+        title: notice.title,
+        content: notice.content,
+        isPublic: !notice.isPublic,
+      });
+
+      setNotice((current) =>
+        current ? { ...current, isPublic: !current.isPublic } : current,
+      );
+      setMenuVisible(false);
+    } catch (error) {
+      setMenuVisible(false);
+
+      if (isAxiosError(error) && error.response?.status === 403) {
+        setErrorMessage('공지 공개 상태를 변경할 권한이 없어요.');
+      } else {
+        setErrorMessage('공지 공개 상태를 변경하지 못했어요.');
       }
-    };
+    } finally {
+      setUpdatingVisibility(false);
+    }
+  };
 
-    fetchNotice();
-  }, [storeId, noticeId]);
+  const handlePressEdit = () => {
+    setMenuVisible(false);
+    router.push({
+      pathname: '/(notice)/[storeId]/notice-create',
+      params: { storeId, noticeId },
+    });
+  };
 
   const createdAt = formatNoticeDate(notice?.createdAt);
   const metaItems = [
@@ -90,16 +142,21 @@ export default function NoticeDetailPage() {
           <View style={styles.menu}>
             <Pressable
               style={styles.menuItem}
-              onPress={() => setMenuVisible(false)}
+              disabled={updatingVisibility}
+              onPress={handleToggleVisibility}
             >
               <NText variant="r14" style={styles.menuText}>
-                {notice?.isPublic ? '비공개로 전환' : '공개로 전환'}
+                {updatingVisibility
+                  ? '변경 중'
+                  : notice?.isPublic
+                    ? '비공개로 전환'
+                    : '공개로 전환'}
               </NText>
             </Pressable>
 
             <Pressable
               style={styles.menuItem}
-              onPress={() => setMenuVisible(false)}
+              onPress={handlePressEdit}
             >
               <NText variant="r14" style={styles.menuText}>
                 수정
@@ -158,7 +215,7 @@ const styles = StyleSheet.create({
     zIndex: 2,
     top: 48,
     right: 0,
-    width: 260,
+    width: 180,
     paddingVertical: 8,
     borderRadius: 20,
     backgroundColor: '#FFFFFF',

--- a/app/(notice)/[storeId]/notice-detail.tsx
+++ b/app/(notice)/[storeId]/notice-detail.tsx
@@ -1,52 +1,214 @@
-import { StyleSheet, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useLocalSearchParams } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
 
+import { Notice } from '@/src/entities/notice/notice';
+import { getNotice } from '@/src/features/notice/api/notice';
+import {
+  typoColorPrimary,
+  typoColorSecondary,
+} from '@/src/init/styles/tokens';
 import NText from '@/src/shared/ui/NText';
 import PageLayout from '@/src/shared/ui/PageLayout';
 
+const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'];
+
+function formatNoticeDate(createdAt?: string) {
+  if (!createdAt) {
+    return '';
+  }
+
+  const date = new Date(createdAt);
+
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
+  return `${date.getMonth() + 1}월 ${date.getDate()}일 (${WEEKDAYS[date.getDay()]})`;
+}
+
 export default function NoticeDetailPage() {
+  const { storeId, noticeId } = useLocalSearchParams<{
+    storeId: string;
+    noticeId: string;
+  }>();
+  const [notice, setNotice] = useState<Notice | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [menuVisible, setMenuVisible] = useState(false);
+
+  useEffect(() => {
+    if (!storeId || !noticeId) {
+      setErrorMessage('공지 정보를 확인할 수 없어요.');
+      setLoading(false);
+      return;
+    }
+
+    const fetchNotice = async () => {
+      try {
+        setLoading(true);
+        setErrorMessage(null);
+
+        const { data } = await getNotice(storeId, noticeId);
+        setNotice(data);
+      } catch {
+        setErrorMessage('공지를 불러오지 못했어요.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchNotice();
+  }, [storeId, noticeId]);
+
+  const createdAt = formatNoticeDate(notice?.createdAt);
+  const metaItems = [
+    createdAt,
+    notice?.authorName,
+    notice ? (notice.isPublic ? '공개' : '비공개') : '',
+  ].filter(Boolean);
+
   return (
-    <PageLayout title="공지">
-      <View style={styles.container}>
-        <NText variant="h2">
-          [필독] 이번 주말 야간 근무자 유의사항
-        </NText>
+    <PageLayout
+      title="공지사항"
+      icon={
+        <Ionicons
+          name="ellipsis-vertical"
+          size={20}
+          color={typoColorPrimary}
+        />
+      }
+      onPressCheckIcon={() => setMenuVisible((visible) => !visible)}
+    >
+      {menuVisible && (
+        <>
+          <Pressable
+            style={styles.menuBackdrop}
+            onPress={() => setMenuVisible(false)}
+          />
+          <View style={styles.menu}>
+            <Pressable
+              style={styles.menuItem}
+              onPress={() => setMenuVisible(false)}
+            >
+              <NText variant="r14" style={styles.menuText}>
+                {notice?.isPublic ? '비공개로 전환' : '공개로 전환'}
+              </NText>
+            </Pressable>
 
-        <View style={styles.metaContainer}>
-          <NText variant="r14">3월 11일 (수)</NText>
-          <NText variant="r14">이지현</NText>
-          <NText variant="r14">공개</NText>
-        </View>
+            <Pressable
+              style={styles.menuItem}
+              onPress={() => setMenuVisible(false)}
+            >
+              <NText variant="r14" style={styles.menuText}>
+                수정
+              </NText>
+            </Pressable>
+          </View>
+        </>
+      )}
 
-        <View style={styles.contentContainer}>
-          <NText variant="r14l">
-            매장 청소 구역이 일부 조정되었습니다.
-            창고 입구와 분리수거장 주변 청소 주기가 변경되었으니
-            새로운 리스트를 확인해 주세요.
-            {'\n\n'}
-            변경된 체크리스트는 가운데 열 게시판에도
-            부착되어 있습니다.
-            {'\n\n'}
-            모든 근무자는 교대시 해당 구역의 청결 상태를
-            상호 확인해 주시기 바랍니다.
-          </NText>
-        </View>
-      </View>
+      <ScrollView
+        contentContainerStyle={styles.container}
+        showsVerticalScrollIndicator={false}
+      >
+        {loading && <NText variant="r14">불러오는 중...</NText>}
+
+        {!loading && errorMessage && (
+          <NText variant="r14">{errorMessage}</NText>
+        )}
+
+        {!loading && notice && (
+          <>
+            <NText variant="h2" style={styles.title}>
+              {notice.title}
+            </NText>
+
+            <View style={styles.metaContainer}>
+              {metaItems.map((item, index) => (
+                <View key={`${index}-${item}`} style={styles.metaItem}>
+                  {index > 0 && <View style={styles.divider} />}
+                  <NText variant="r14" style={styles.metaText}>
+                    {item}
+                  </NText>
+                </View>
+              ))}
+            </View>
+
+            <View style={styles.contentContainer}>
+              <NText variant="r14l" style={styles.content}>
+                {notice.content?.trim() || '내용이 표시됩니다'}
+              </NText>
+            </View>
+          </>
+        )}
+      </ScrollView>
     </PageLayout>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    paddingTop: 16,
+  menuBackdrop: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 1,
   },
-
+  menu: {
+    position: 'absolute',
+    zIndex: 2,
+    top: 48,
+    right: 0,
+    width: 260,
+    paddingVertical: 8,
+    borderRadius: 20,
+    backgroundColor: '#FFFFFF',
+    shadowColor: '#000000',
+    shadowOffset: {
+      width: 0,
+      height: 8,
+    },
+    shadowOpacity: 0.12,
+    shadowRadius: 20,
+    elevation: 8,
+  },
+  menuItem: {
+    minHeight: 52,
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+  },
+  menuText: {
+    color: typoColorSecondary,
+  },
+  container: {
+    flexGrow: 1,
+    paddingTop: 24,
+    paddingBottom: 32,
+  },
+  title: {
+    color: typoColorPrimary,
+  },
   metaContainer: {
     flexDirection: 'row',
-    gap: 12,
-    marginTop: 12,
+    alignItems: 'center',
+    marginTop: 16,
   },
-
+  metaItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  metaText: {
+    color: typoColorSecondary,
+  },
+  divider: {
+    width: 1,
+    height: 14,
+    marginHorizontal: 10,
+    backgroundColor: '#D9D9D9',
+  },
   contentContainer: {
-    marginTop: 32,
+    marginTop: 28,
+  },
+  content: {
+    color: typoColorPrimary,
   },
 });

--- a/app/[storeId]/_layout.tsx
+++ b/app/[storeId]/_layout.tsx
@@ -28,6 +28,9 @@ export default function Layout() {
           (store: MyStoreItem) => store.storeId === storeId,
         );
 
+        console.log('내 매장 목록:', myStores);
+        console.log('현재 매장 권한:', currentStore);
+
         setUser({
           currentStoreAccessLoaded: true,
           currentStoreId: currentStore?.storeId ?? null,

--- a/src/entities/notice/notice.ts
+++ b/src/entities/notice/notice.ts
@@ -1,6 +1,10 @@
 export interface Notice {
-  noticeId: string;
+  id: string;
+  noticeId?: string;
   title: string; //'이번주 근무표 안내';
-  content: string; // '이번주 근무표를 확인해주세요.';
+  content?: string | null; // '이번주 근무표를 확인해주세요.';
   isPublic: boolean;
+  authorName?: string;
+  createdAt?: string;
+  isRead?: boolean;
 }

--- a/src/features/notice/api/notice.ts
+++ b/src/features/notice/api/notice.ts
@@ -1,0 +1,57 @@
+import { apiClient } from '@/src/shared/api/api';
+
+export type NoticeFilter = 'public' | 'private';
+
+type NoticeRequest = {
+  title: string;
+  content: string;
+  isPublic: boolean;
+};
+
+// 공지 목록 조회
+export function getNotices(
+    storeId: string,
+    filter?: NoticeFilter
+) {
+  return apiClient.get(`/stores/${storeId}/notices`, {
+    params: filter ? { filter } : undefined,
+  });
+}
+
+// 공지 작성
+export function createNotice(
+    storeId: string,
+    data: NoticeRequest
+) {
+  return apiClient.post(`/stores/${storeId}/notices`, data);
+}
+
+// 공지 상세 조회
+export function getNotice(
+    storeId: string,
+    noticeId: string
+) {
+  return apiClient.get(`/stores/${storeId}/notices/${noticeId}`);
+}
+
+// 공지 수정
+export function updateNotice(
+  storeId: string,
+  noticeId: string,
+  data: NoticeRequest,
+) {
+  return apiClient.patch(
+    `/stores/${storeId}/notices/${noticeId}`,
+    data,
+  );
+}
+
+// 공지 삭제
+export function deleteNotice(
+    storeId: string,
+    noticeId: string
+) {
+  return apiClient.delete(
+    `/stores/${storeId}/notices/${noticeId}`,
+  );
+}

--- a/src/features/notice/api/notice.ts
+++ b/src/features/notice/api/notice.ts
@@ -14,7 +14,7 @@ export function getNotices(
     filter?: NoticeFilter
 ) {
   return apiClient.get(`/stores/${storeId}/notices`, {
-    params: filter ? { filter } : undefined,
+    params: filter ? { filter } : { filter: 'all' },
   });
 }
 

--- a/src/pages/store/home/HomePage.tsx
+++ b/src/pages/store/home/HomePage.tsx
@@ -1,8 +1,10 @@
+import { useFocusEffect } from '@react-navigation/native';
 import { router, useLocalSearchParams } from 'expo-router';
-import { useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { MemberRole } from '@/src/entities/member/member';
 import { Notice } from '@/src/entities/notice/notice';
+import { getNotices } from '@/src/features/notice/api/notice';
 import { getDashboardInfos } from '@/src/features/store/api/dashboard';
 import useUser from '@/src/features/user/lib/useUser';
 import PageLayout from '@/src/shared/ui/PageLayout';
@@ -32,32 +34,34 @@ export default function HomePage() {
   const [schedule, setSchedule] = useState<TypeSchedules[]>([]);
   const [notices, setNotices] = useState<Notice[]>([]);
 
-  useEffect(() => {
-    const fetch = async () => {
-      try {
-        //{"header": {"role": "staff", "storeName": "나날이 ", "unreadNotificationCount": 0}, "notices": [], "schedules": {"current": null, "upcoming": []}}
-        const { data } = await getDashboardInfos(storeId);
-
-        const { header, schedules, notices: dashboardNotices } = data;
-        setHeaderInfo(header);
-        setNotices(
-          dashboardNotices.map((notice: Notice) => ({
-            ...notice,
-            id: notice.id ?? notice.noticeId,
-          })),
-        );
-
-        setSchedule([
-          ...(schedules?.current ? [schedules.current] : []),
-          ...schedules.upcoming,
-        ]);
-      } catch (error) {
-        console.log(error);
-        //todo: 403 -> not found redirect
+  useFocusEffect(
+    useCallback(() => {
+      if (!storeId) {
+        return;
       }
-    };
-    fetch();
-  }, [storeId]);
+
+      const fetchDashboard = async () => {
+        try {
+          const [{ data: dashboard }, { data: noticeList }] = await Promise.all([
+            getDashboardInfos(storeId),
+            getNotices(storeId),
+          ]);
+          const { header, schedules } = dashboard;
+
+          setHeaderInfo(header);
+          setNotices((noticeList as Notice[]).slice(0, 3));
+          setSchedule([
+            ...(schedules?.current ? [schedules.current] : []),
+            ...schedules.upcoming,
+          ]);
+        } catch {
+          // todo: 403 -> not found redirect
+        }
+      };
+
+      fetchDashboard();
+    }, [storeId]),
+  );
   return (
     <PageLayout showHeader={false}>
       <StoreHeader

--- a/src/pages/store/home/HomePage.tsx
+++ b/src/pages/store/home/HomePage.tsx
@@ -2,12 +2,13 @@ import { router, useLocalSearchParams } from 'expo-router';
 import { useEffect, useState } from 'react';
 
 import { MemberRole } from '@/src/entities/member/member';
+import { Notice } from '@/src/entities/notice/notice';
 import { getDashboardInfos } from '@/src/features/store/api/dashboard';
 import useUser from '@/src/features/user/lib/useUser';
 import PageLayout from '@/src/shared/ui/PageLayout';
+import NoticeWidget from '@/src/widgets/notice/NoticeWidget';
 import CurrentWeekSchedules from '@/src/widgets/store/home/CurrentWeekSchedules';
 import StoreHeader from '@/src/widgets/store/home/StoreHeader';
-import NoticeWidget from '@/src/widgets/notice/NoticeWidget';
 
 type TypeHeaderInfo = {
   role: MemberRole;
@@ -29,6 +30,7 @@ export default function HomePage() {
   const [headerInfo, setHeaderInfo] = useState<TypeHeaderInfo | null>(null);
   //todo: 스케줄 구현 후 데이터 삭제
   const [schedule, setSchedule] = useState<TypeSchedules[]>([]);
+  const [notices, setNotices] = useState<Notice[]>([]);
 
   useEffect(() => {
     const fetch = async () => {
@@ -36,8 +38,14 @@ export default function HomePage() {
         //{"header": {"role": "staff", "storeName": "나날이 ", "unreadNotificationCount": 0}, "notices": [], "schedules": {"current": null, "upcoming": []}}
         const { data } = await getDashboardInfos(storeId);
 
-        const { header, schedules } = data;
+        const { header, schedules, notices: dashboardNotices } = data;
         setHeaderInfo(header);
+        setNotices(
+          dashboardNotices.map((notice: Notice) => ({
+            ...notice,
+            id: notice.id ?? notice.noticeId,
+          })),
+        );
 
         setSchedule([
           ...(schedules?.current ? [schedules.current] : []),
@@ -60,7 +68,15 @@ export default function HomePage() {
         isActiveOwner={false}
       />
       <CurrentWeekSchedules schedules={schedule} />
-        <NoticeWidget onPressHeader={() => {
+        <NoticeWidget 
+        notices={notices}
+        onPressNotice={(noticeId) => {
+          router.push({
+            pathname: '/(notice)/[storeId]/notice-detail',
+            params: { storeId, noticeId },
+          });
+        }}
+        onPressHeader={() => {
           router.push({ 
             pathname: `/(notice)/[storeId]/notice`,
             params: { storeId, displayStoreName }

--- a/src/pages/store/home/HomePage.tsx
+++ b/src/pages/store/home/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useLocalSearchParams } from 'expo-router';
+import { router, useLocalSearchParams } from 'expo-router';
 import { useEffect, useState } from 'react';
 
 import { MemberRole } from '@/src/entities/member/member';
@@ -7,6 +7,7 @@ import useUser from '@/src/features/user/lib/useUser';
 import PageLayout from '@/src/shared/ui/PageLayout';
 import CurrentWeekSchedules from '@/src/widgets/store/home/CurrentWeekSchedules';
 import StoreHeader from '@/src/widgets/store/home/StoreHeader';
+import NoticeWidget from '@/src/widgets/notice/NoticeWidget';
 
 type TypeHeaderInfo = {
   role: MemberRole;
@@ -59,6 +60,12 @@ export default function HomePage() {
         isActiveOwner={false}
       />
       <CurrentWeekSchedules schedules={schedule} />
+        <NoticeWidget onPressHeader={() => {
+          router.push({ 
+            pathname: `/(notice)/[storeId]/notice`,
+            params: { storeId, displayStoreName }
+           })
+        }} />
     </PageLayout>
   );
 }

--- a/src/pages/store/home/NoticePage.tsx
+++ b/src/pages/store/home/NoticePage.tsx
@@ -1,24 +1,102 @@
-import { canManageNotice } from '@/src/features/permission/lib/access';
-import useCurrentStoreAccess from '@/src/features/permission/lib/useCurrentStoreAccess';
-import AccessDenied from '@/src/shared/ui/AccessDenied';
-import NText from '@/src/shared/ui/NText';
+import { useState } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
 import PageLayout from '@/src/shared/ui/PageLayout';
+import NoticeCard, {
+  Notice,
+} from '@/src/widgets/notice/NoticeCard';
+import NoticeTabs, {
+  NoticeTabType,
+} from '@/src/widgets/notice/NoticeTabs';
+
+const MOCK_NOTICES: Notice[] = [
+  {
+    id: 1,
+    title: '[필독] 이번 주말 야간 근무자 유의사항',
+    content:
+      '매장 청소 및 재고 확인 체크리스트를 반드시 확인해 주세요.',
+    createdAt: '2026.06.21',
+  },
+  {
+    id: 2,
+    title: '매장 청소 체크리스트 업데이트 안내',
+    content: '새로운 청소 구역이 추가되었습니다.',
+    createdAt: '2026.06.20',
+  },
+  {
+    id: 3,
+    title: '급여 정산 관련 공지',
+    content: '급여 정산 일정이 변경되었습니다.',
+    createdAt: '2026.06.19',
+  },
+];
 
 export default function NoticePage() {
-  const access = useCurrentStoreAccess();
+  const [tab, setTab] = useState<NoticeTabType>('all');
 
-  if (!canManageNotice(access)) {
-    return (
-      <AccessDenied
-        title="공지 화면에 접근할 수 없어요"
-        message="공지 관리 권한이 있는 사용자만 접근할 수 있어요"
-      />
-    );
-  }
+  const notices = MOCK_NOTICES;
 
   return (
     <PageLayout title="공지">
-      <NText variant="r14">NoticePage</NText>
+      <NoticeTabs
+        value={tab}
+        onChange={setTab}
+      />
+
+      <View style={styles.list}>
+        {notices.map((notice) => (
+          <NoticeCard
+            key={notice.id}
+            notice={notice}
+          />
+        ))}
+      </View>
+
+      <Pressable
+        style={styles.floatingButton}
+        onPress={() => {
+          console.log('공지 작성');
+        }}
+      >
+        <Ionicons
+          name="add"
+          size={28}
+          color="#fff"
+        />
+      </Pressable>
     </PageLayout>
   );
 }
+
+const styles = StyleSheet.create({
+  list: {
+    marginTop: 16,
+  },
+
+  floatingButton: {
+    position: 'absolute',
+    right: 24,
+    bottom: 24,
+
+    width: 56,
+    height: 56,
+
+    borderRadius: 28,
+
+    justifyContent: 'center',
+    alignItems: 'center',
+
+    backgroundColor: '#6EA8FF',
+
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 4,
+    },
+    shadowOpacity: 0.15,
+    shadowRadius: 8,
+
+    elevation: 4,
+  },
+});

--- a/src/pages/store/home/NoticePage.tsx
+++ b/src/pages/store/home/NoticePage.tsx
@@ -4,8 +4,10 @@ import { router, useLocalSearchParams } from 'expo-router';
 import { useCallback, useState } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 
+import { MemberRole } from '@/src/entities/member/member';
 import { Notice } from '@/src/entities/notice/notice';
 import { getNotices, NoticeFilter } from '@/src/features/notice/api/notice';
+import useCurrentStoreAccess from '@/src/features/permission/lib/useCurrentStoreAccess';
 import NText from '@/src/shared/ui/NText';
 import PageLayout from '@/src/shared/ui/PageLayout';
 import NoticeCard from '@/src/widgets/notice/NoticeCard';
@@ -36,6 +38,13 @@ import NoticeTabs, {
 
 export default function NoticePage() {
   const { storeId } = useLocalSearchParams<{ storeId: string }>();
+  const access = useCurrentStoreAccess();
+  const canViewPrivateNotice =
+    access.isOwner || access.role === MemberRole.MANAGER;
+  const canManageNotice =
+    access.isOwner ||
+    (access.role === MemberRole.MANAGER &&
+      !!access.permissions?.canManageNotice);
 
   const [tab, setTab] = useState<NoticeTabType>('all');
   const [notices, setNotices] = useState<Notice[]>([]);
@@ -43,7 +52,7 @@ export default function NoticePage() {
 
   useFocusEffect(
     useCallback(() => {
-      if (!storeId) {
+      if (!access.loaded || !storeId) {
         return;
       }
 
@@ -51,8 +60,11 @@ export default function NoticePage() {
         try {
           setLoading(true);
 
-          const filter: NoticeFilter | undefined =
-            tab === 'all' ? undefined : tab;
+          const filter: NoticeFilter | undefined = !canViewPrivateNotice
+            ? 'public'
+            : tab === 'all'
+              ? undefined
+              : tab;
 
           const { data } = await getNotices(storeId, filter);
           setNotices(data);
@@ -64,15 +76,21 @@ export default function NoticePage() {
       };
 
       fetchNotices();
-    }, [storeId, tab]),
+    }, [access.loaded, canViewPrivateNotice, storeId, tab]),
   );
+
+  if (!access.loaded) {
+    return <View />;
+  }
 
   return (
     <PageLayout title="공지">
-      <NoticeTabs
-        value={tab}
-        onChange={setTab}
-      />
+      {canViewPrivateNotice && (
+        <NoticeTabs
+          value={tab}
+          onChange={setTab}
+        />
+      )}
 
       <View style={styles.list}>
         {loading && <NText variant="r14">불러오는 중...</NText>}
@@ -92,21 +110,23 @@ export default function NoticePage() {
         ))}
       </View>
 
-      <Pressable
-        style={styles.floatingButton}
-        onPress={() => {
-          router.push({
-            pathname: '/(notice)/[storeId]/notice-create',
-            params: { storeId },
-          });
-        }}
-      >
-        <Ionicons
-          name="add"
-          size={28}
-          color="#fff"
-        />
-      </Pressable>
+      {canManageNotice && (
+        <Pressable
+          style={styles.floatingButton}
+          onPress={() => {
+            router.push({
+              pathname: '/(notice)/[storeId]/notice-create',
+              params: { storeId },
+            });
+          }}
+        >
+          <Ionicons
+            name="add"
+            size={28}
+            color="#fff"
+          />
+        </Pressable>
+      )}
     </PageLayout>
   );
 }

--- a/src/pages/store/home/NoticePage.tsx
+++ b/src/pages/store/home/NoticePage.tsx
@@ -1,6 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
+import { useFocusEffect } from '@react-navigation/native';
 import { router, useLocalSearchParams } from 'expo-router';
-import { useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 
 import { Notice } from '@/src/entities/notice/notice';
@@ -34,36 +35,37 @@ import NoticeTabs, {
 // ];
 
 export default function NoticePage() {
-const { storeId } = useLocalSearchParams<{ storeId: string }>();
+  const { storeId } = useLocalSearchParams<{ storeId: string }>();
 
   const [tab, setTab] = useState<NoticeTabType>('all');
   const [notices, setNotices] = useState<Notice[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
 
-  useEffect(() => {
-    if(!storeId) {return;}
-
-    const fetchNotices = async () => {
-      try {
-        setLoading(true);
-
-        const filter: NoticeFilter | undefined =
-          tab === 'all' ? undefined : tab;
-          
-        const { data } = await getNotices(storeId, filter);
-
-        console.log('공지 목록 응답:', data);
-        setNotices(data);
-      } catch (error) {
-        console.error('공지 목록 조회 실패:', error);
-        setNotices([]);
-      } finally {
-        setLoading(false);
+  useFocusEffect(
+    useCallback(() => {
+      if (!storeId) {
+        return;
       }
-    };
 
-    fetchNotices();
-  }, [storeId, tab]);
+      const fetchNotices = async () => {
+        try {
+          setLoading(true);
+
+          const filter: NoticeFilter | undefined =
+            tab === 'all' ? undefined : tab;
+
+          const { data } = await getNotices(storeId, filter);
+          setNotices(data);
+        } catch {
+          setNotices([]);
+        } finally {
+          setLoading(false);
+        }
+      };
+
+      fetchNotices();
+    }, [storeId, tab]),
+  );
 
   return (
     <PageLayout title="공지">
@@ -79,6 +81,7 @@ const { storeId } = useLocalSearchParams<{ storeId: string }>();
           <NoticeCard
             key={notice.id}
             notice={notice}
+            variant="list"
             onPress={() => {
               router.push({
                 pathname: '/(notice)/[storeId]/notice-detail',
@@ -92,7 +95,10 @@ const { storeId } = useLocalSearchParams<{ storeId: string }>();
       <Pressable
         style={styles.floatingButton}
         onPress={() => {
-          console.log('공지 작성');
+          router.push({
+            pathname: '/(notice)/[storeId]/notice-create',
+            params: { storeId },
+          });
         }}
       >
         <Ionicons
@@ -107,7 +113,7 @@ const { storeId } = useLocalSearchParams<{ storeId: string }>();
 
 const styles = StyleSheet.create({
   list: {
-    marginTop: 16,
+    marginTop: 4,
   },
 
   floatingButton: {

--- a/src/pages/store/home/NoticePage.tsx
+++ b/src/pages/store/home/NoticePage.tsx
@@ -1,41 +1,69 @@
-import { useState } from 'react';
-import { Pressable, StyleSheet, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { router, useLocalSearchParams } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
 
+import { Notice } from '@/src/entities/notice/notice';
+import { getNotices, NoticeFilter } from '@/src/features/notice/api/notice';
+import NText from '@/src/shared/ui/NText';
 import PageLayout from '@/src/shared/ui/PageLayout';
-import NoticeCard, {
-  Notice,
-} from '@/src/widgets/notice/NoticeCard';
+import NoticeCard from '@/src/widgets/notice/NoticeCard';
 import NoticeTabs, {
   NoticeTabType,
 } from '@/src/widgets/notice/NoticeTabs';
-
-const MOCK_NOTICES: Notice[] = [
-  {
-    id: 1,
-    title: '[필독] 이번 주말 야간 근무자 유의사항',
-    content:
-      '매장 청소 및 재고 확인 체크리스트를 반드시 확인해 주세요.',
-    createdAt: '2026.06.21',
-  },
-  {
-    id: 2,
-    title: '매장 청소 체크리스트 업데이트 안내',
-    content: '새로운 청소 구역이 추가되었습니다.',
-    createdAt: '2026.06.20',
-  },
-  {
-    id: 3,
-    title: '급여 정산 관련 공지',
-    content: '급여 정산 일정이 변경되었습니다.',
-    createdAt: '2026.06.19',
-  },
-];
+// const MOCK_NOTICES: Notice[] = [
+//   {
+//     id: 1,
+//     title: '[필독] 이번 주말 야간 근무자 유의사항',
+//     content:
+//       '매장 청소 및 재고 확인 체크리스트를 반드시 확인해 주세요.',
+//     createdAt: '2026.06.21',
+//   },
+//   {
+//     id: 2,
+//     title: '매장 청소 체크리스트 업데이트 안내',
+//     content: '새로운 청소 구역이 추가되었습니다.',
+//     createdAt: '2026.06.20',
+//   },
+//   {
+//     id: 3,
+//     title: '급여 정산 관련 공지',
+//     content: '급여 정산 일정이 변경되었습니다.',
+//     createdAt: '2026.06.19',
+//   },
+// ];
 
 export default function NoticePage() {
-  const [tab, setTab] = useState<NoticeTabType>('all');
+const { storeId } = useLocalSearchParams<{ storeId: string }>();
 
-  const notices = MOCK_NOTICES;
+  const [tab, setTab] = useState<NoticeTabType>('all');
+  const [notices, setNotices] = useState<Notice[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+
+  useEffect(() => {
+    if(!storeId) {return;}
+
+    const fetchNotices = async () => {
+      try {
+        setLoading(true);
+
+        const filter: NoticeFilter | undefined =
+          tab === 'all' ? undefined : tab;
+          
+        const { data } = await getNotices(storeId, filter);
+
+        console.log('공지 목록 응답:', data);
+        setNotices(data);
+      } catch (error) {
+        console.error('공지 목록 조회 실패:', error);
+        setNotices([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchNotices();
+  }, [storeId, tab]);
 
   return (
     <PageLayout title="공지">
@@ -45,10 +73,18 @@ export default function NoticePage() {
       />
 
       <View style={styles.list}>
-        {notices.map((notice) => (
+        {loading && <NText variant="r14">불러오는 중...</NText>}
+
+        {!loading && notices.map((notice) => (
           <NoticeCard
             key={notice.id}
             notice={notice}
+            onPress={() => {
+              router.push({
+                pathname: '/(notice)/[storeId]/notice-detail',
+                params: { storeId, noticeId: notice.id },
+              });
+            }}
           />
         ))}
       </View>

--- a/src/shared/api/api.ts
+++ b/src/shared/api/api.ts
@@ -15,8 +15,8 @@ import {
 } from '@/src/features/auth/lib/storage';
 
 export const apiClient = axios.create({
-  baseURL: 'https://nanaly-backend-dev.up.railway.app/',
-  timeout: 1000,
+  baseURL: 'https://staging-api.nanaly-schedule.com/',
+  timeout: 10000,
 });
 
 // 요청 인터셉터: 모든 API 요청에 Access Token 자동 추가

--- a/src/shared/api/api.ts
+++ b/src/shared/api/api.ts
@@ -91,24 +91,15 @@ async function refreshAccessToken(): Promise<string | null> {
       return null;
     }
 
-    // Refresh Token을 Authorization 헤더에 Bearer 형식으로 전송
     const { data } = await axios.post<{
       accessToken: string;
-      refreshToken: string; // 새 Refresh Token도 함께 받아야 함
+      refreshToken: string;
     }>(
-      `${apiClient.defaults.baseURL}/auth/refresh`, // 실제 엔드포인트 확인 필요
-      {},
-      {
-        headers: {
-          Authorization: `Bearer ${refreshToken}`, // Bearer 형식으로 전송
-        },
-      },
+      `${apiClient.defaults.baseURL}auth/refresh`,
+      { refreshToken },
     );
 
-    // 새 Access Token 저장
     await saveAccessToken(data.accessToken);
-
-    // 새 Refresh Token도 저장 (기존 토큰 폐기되므로 필수!)
     await saveRefreshToken(data.refreshToken);
 
     return data.accessToken;

--- a/src/shared/ui/Header.tsx
+++ b/src/shared/ui/Header.tsx
@@ -1,10 +1,9 @@
 import { useRouter } from 'expo-router';
-import { PropsWithChildren, ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 
 import { typoColorPrimary } from '@/src/init/styles/tokens';
 
-import CheckIcon from '../assets/CheckIcon';
 import LeftArrowIcon from '../assets/LeftArrowIcon';
 import NText from './NText';
 
@@ -79,6 +78,9 @@ const styles = StyleSheet.create({
   },
   right: {
     right: 2,
-    top: 8,
+    top: 0,
+    bottom: 0,
+    justifyContent: 'center',
+    paddingVertical: 0,
   },
 });

--- a/src/widgets/notice/NoticeCard.tsx
+++ b/src/widgets/notice/NoticeCard.tsx
@@ -1,61 +1,131 @@
 import { Ionicons } from '@expo/vector-icons';
-import { Pressable, Text, View } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { Notice } from '@/src/entities/notice/notice';
 
 type NoticeCardProps = {
   notice: Notice;
   onPress?: () => void;
+  variant?: 'card' | 'list';
 }
 
-export default function NoticeCard({ notice, onPress }: NoticeCardProps) {
+const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'];
+
+function formatNoticeDate(createdAt?: string) {
+  if (!createdAt) {
+    return '';
+  }
+
+  const date = new Date(createdAt);
+
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
+  return `${date.getMonth() + 1}월 ${date.getDate()}일 (${WEEKDAYS[date.getDay()]})`;
+}
+
+export default function NoticeCard({
+  notice,
+  onPress,
+  variant = 'card',
+}: NoticeCardProps) {
+    const isList = variant === 'list';
+    const createdAt = formatNoticeDate(notice.createdAt);
+
     return (
         <Pressable
             disabled={!onPress}
             onPress={onPress}
-            style={{
-                backgroundColor: '#fff',
-        borderRadius: 16,
-        padding: 16,
-        marginBottom: 12,
-        flexDirection: 'row',
-        alignItems: 'center',
-        }}
+            style={[styles.container, isList ? styles.list : styles.card]}
         >
         <View
-            style={{
-                width: 40,
-                height: 40,
-                borderRadius: 20,
-                backgroundColor: '#6EA8FF',
-                justifyContent: 'center',
-                alignItems: 'center',
-                marginRight: 12,
-            }}
+            style={[
+                styles.icon,
+                isList && styles.listIcon,
+                {
+                    backgroundColor: notice.isPublic
+                        ? '#86BEFF'
+                        : '#D9D9D9',
+                },
+            ]}
             >
-                <Ionicons name="notifications" size={20} color="#fff" />
+                <Ionicons
+                    name={
+                        notice.isPublic
+                            ? 'lock-open-outline'
+                            : 'lock-closed-outline'
+                    }
+                    size={20}
+                    color="#fff"
+                />
             </View>
             <View style={{flex: 1}}>
                 <Text
                     numberOfLines={1}
-                    style={{
-                        fontSize: 16,
-                        fontWeight: 700,
-                        marginBottom: 6,
-                    }}
+                    style={[styles.title, isList && styles.listTitle]}
                 >
                     {notice.title}
                 </Text>
                 <Text
                     numberOfLines={2}
-                    style={{
-                        fontSize: 14,
-                        color: '#666',
-                    }}
+                    style={styles.content}
                 >
                     {notice.content?.trim() || '내용이 표시됩니다'}
                 </Text>
+                {isList && createdAt && (
+                    <Text style={styles.date}>{createdAt}</Text>
+                )}
             </View>
         </Pressable>
     );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  card: {
+    marginBottom: 12,
+    padding: 16,
+    borderRadius: 16,
+    backgroundColor: '#FFFFFF',
+  },
+  list: {
+    alignItems: 'flex-start',
+    marginBottom: 28,
+  },
+  icon: {
+    width: 40,
+    height: 40,
+    marginRight: 14,
+    borderRadius: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  listIcon: {
+    marginTop: 16,
+  },
+  title: {
+    marginBottom: 6,
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#333333',
+  },
+  listTitle: {
+    fontSize: 14,
+    lineHeight: 18,
+  },
+  content: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: '#555555',
+  },
+  date: {
+    marginTop: 12,
+    fontSize: 14,
+    lineHeight: 18,
+    color: '#666666',
+  },
+});

--- a/src/widgets/notice/NoticeCard.tsx
+++ b/src/widgets/notice/NoticeCard.tsx
@@ -1,0 +1,63 @@
+import {Text, View} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+export type Notice ={
+    id: number;
+    title: string;
+    content: string;
+    createdAt: string;
+}
+
+type NoticeCardProps = {
+    notice: Notice;
+}
+
+export default function NoticeCard({notice}: NoticeCardProps) {
+    return (
+        <View
+            style={{
+                backgroundColor: '#fff',
+        borderRadius: 16,
+        padding: 16,
+        marginBottom: 12,
+        flexDirection: 'row',
+        alignItems: 'center',
+        }}
+        >
+        <View
+            style={{
+                width: 40,
+                height: 40,
+                borderRadius: 20,
+                backgroundColor: '#6EA8FF',
+                justifyContent: 'center',
+                alignItems: 'center',
+                marginRight: 12,
+            }}
+            >
+                <Ionicons name="notifications" size={20} color="#fff" />
+            </View>
+            <View style={{flex: 1}}>
+                <Text
+                    numberOfLines={1}
+                    style={{
+                        fontSize: 16,
+                        fontWeight: 700,
+                        marginBottom: 6,
+                    }}
+                >
+                    {notice.title}
+                </Text>
+                <Text
+                    numberOfLines={2}
+                    style={{
+                        fontSize: 14,
+                        color: '#666',
+                    }}
+                >
+                    {notice.content}
+                </Text>
+            </View>
+        </View>
+    );
+}   

--- a/src/widgets/notice/NoticeCard.tsx
+++ b/src/widgets/notice/NoticeCard.tsx
@@ -1,20 +1,18 @@
-import {Text, View} from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { Pressable, Text, View } from 'react-native';
 
-export type Notice ={
-    id: number;
-    title: string;
-    content: string;
-    createdAt: string;
-}
+import { Notice } from '@/src/entities/notice/notice';
 
 type NoticeCardProps = {
-    notice: Notice;
+  notice: Notice;
+  onPress?: () => void;
 }
 
-export default function NoticeCard({notice}: NoticeCardProps) {
+export default function NoticeCard({ notice, onPress }: NoticeCardProps) {
     return (
-        <View
+        <Pressable
+            disabled={!onPress}
+            onPress={onPress}
             style={{
                 backgroundColor: '#fff',
         borderRadius: 16,
@@ -55,9 +53,9 @@ export default function NoticeCard({notice}: NoticeCardProps) {
                         color: '#666',
                     }}
                 >
-                    {notice.content}
+                    {notice.content?.trim() || '내용이 표시됩니다'}
                 </Text>
             </View>
-        </View>
+        </Pressable>
     );
-}   
+}

--- a/src/widgets/notice/NoticeCard.tsx
+++ b/src/widgets/notice/NoticeCard.tsx
@@ -51,11 +51,7 @@ export default function NoticeCard({
             ]}
             >
                 <Ionicons
-                    name={
-                        notice.isPublic
-                            ? 'lock-open-outline'
-                            : 'lock-closed-outline'
-                    }
+                    name="megaphone-outline"
                     size={20}
                     color="#fff"
                 />

--- a/src/widgets/notice/NoticeHeader.tsx
+++ b/src/widgets/notice/NoticeHeader.tsx
@@ -1,0 +1,31 @@
+import { Pressable, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+type NoticeHeaderProps = {
+  onPress?: () => void;
+};
+
+export default function NoticeHeader({ onPress }: NoticeHeaderProps) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={{
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        marginBottom: 12,
+      }}
+    >
+      <Text
+        style={{
+          fontSize: 20,
+          fontWeight: '700',
+        }}
+      >
+        공지사항
+      </Text>
+
+      <Ionicons name='chevron-forward' size={20} color='#666' />
+    </Pressable>
+  );
+}

--- a/src/widgets/notice/NoticeTabs.tsx
+++ b/src/widgets/notice/NoticeTabs.tsx
@@ -1,4 +1,5 @@
-import { Pressable, View, StyleSheet } from 'react-native';
+import { Pressable, StyleSheet,View } from 'react-native';
+
 import NText from '@/src/shared/ui/NText';
 
 export type NoticeTabType = 'all' | 'public' | 'private'
@@ -25,8 +26,8 @@ export default function NoticeTabs({
         <View
             style={{
                 flexDirection: 'row',
-                gap: 20,
-                marginBottom: 20,
+                gap: 24,
+                marginBottom: 22,
             }}
         >
             {TABS.map((tab)=>{
@@ -38,7 +39,7 @@ export default function NoticeTabs({
                     style={styles.tab}
                     >
                         <NText
-                            variant='r14'
+                            variant='m16'
                             style={[
                                 styles.label,
                                 selected && styles.selectedLabel,
@@ -63,7 +64,7 @@ const styles = StyleSheet.create({
   },
   tab: {
     alignItems: 'center',
-    paddingBottom: 8,
+    paddingBottom: 10,
   },
   label: {
     color: '#A0A0A0',
@@ -72,9 +73,12 @@ const styles = StyleSheet.create({
     color: '#222222',
   },
   indicator: {
-    marginTop: 6,
+    position: 'absolute',
+    right: 0,
+    bottom: 0,
+    left: 0,
     width: '100%',
-    height: 2,
+    height: 3,
     backgroundColor: '#222222',
   },
 });

--- a/src/widgets/notice/NoticeTabs.tsx
+++ b/src/widgets/notice/NoticeTabs.tsx
@@ -1,0 +1,80 @@
+import { Pressable, View, StyleSheet } from 'react-native';
+import NText from '@/src/shared/ui/NText';
+
+export type NoticeTabType = 'all' | 'public' | 'private'
+
+type NoticeTabsProps = {
+    value: NoticeTabType;
+    onChange:(tab:NoticeTabType) => void;
+}
+
+const TABS:{
+    label: string;
+    value: NoticeTabType;
+}[] =[
+    {label: '전체', value:'all'},
+    {label: '공개', value:'public'},
+    {label: '비공개', value:'private'}
+]
+
+export default function NoticeTabs({
+    value,
+    onChange,
+}:NoticeTabsProps) {
+    return (
+        <View
+            style={{
+                flexDirection: 'row',
+                gap: 20,
+                marginBottom: 20,
+            }}
+        >
+            {TABS.map((tab)=>{
+                const selected = value === tab.value;
+                return (
+                    <Pressable
+                    key={tab.value}
+                    onPress={()=> onChange(tab.value)}
+                    style={styles.tab}
+                    >
+                        <NText
+                            variant='r14'
+                            style={[
+                                styles.label,
+                                selected && styles.selectedLabel,
+
+                            ]}
+                        >
+                                {tab.label}
+                            </NText>
+
+                            {selected && <View style={styles.indicator}/>}
+                    </Pressable>
+                )
+            })}
+        </View>
+    )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    gap: 20,
+  },
+  tab: {
+    alignItems: 'center',
+    paddingBottom: 8,
+  },
+  label: {
+    color: '#A0A0A0',
+  },
+  selectedLabel: {
+    color: '#222222',
+  },
+  indicator: {
+    marginTop: 6,
+    width: '100%',
+    height: 2,
+    backgroundColor: '#222222',
+  },
+});

--- a/src/widgets/notice/NoticeWidget.tsx
+++ b/src/widgets/notice/NoticeWidget.tsx
@@ -1,42 +1,39 @@
 import { View } from 'react-native';
-import NoticeCard, { Notice } from './NoticeCard';
+
+import { Notice } from '@/src/entities/notice/notice';
+
+import NoticeCard from './NoticeCard';
 import NoticeHeader from './NoticeHeader';
 
-const MOCK_NOTICES: Notice[] = [
-    {
-    id: 1,
-    title: '[필독] 이번 주말 야간 근무자 유의사항',
-    content: '매장 청소 및 재고 확인 체크리스트를 반드시 확인해 주세요.',
-    createdAt: '2024-06-01T10:00:00Z',
-  },
-  {
-    id: 2,
-    title: '매장 청소 체크리스트 업데이트 안내',
-    content: '새로운 청소 구역이 추가되었습니다.',
-    createdAt: '2024-06-02T10:00:00Z',
-  },
-  {
-    id: 3,
-    title: '3월 급여 정산 관련 공지',
-    content: '급여 정산일이 공휴일인 관계로 하루 일찍 지급될 예정입니다.',
-    createdAt: '2024-06-03T10:00:00Z',
-  },
-];
-
 type NoticeWidgetProps = {
+  notices: Notice[];
   onPressHeader?: () => void;
+  onPressNotice?: (noticeId: string) => void;
 };
 
 
-export default function NoticeWidget({ onPressHeader }: NoticeWidgetProps ) {
+export default function NoticeWidget({
+  notices,
+  onPressHeader,
+  onPressNotice,
+}: NoticeWidgetProps) {
     return (
         <View>
             <NoticeHeader onPress={onPressHeader} />
-            {MOCK_NOTICES.map((notice)=>(
+            {notices.map((notice, index) => {
+              const noticeId = notice.id ?? notice.noticeId;
+
+              return (
                 <NoticeCard
-                    key={notice.id}
+                    key={noticeId ?? `notice-${index}`}
                     notice={notice}
+                    onPress={
+                      noticeId
+                        ? () => onPressNotice?.(noticeId)
+                        : undefined
+                    }
                 />
-            ))}
+              );
+            })}
         </View>
     )}

--- a/src/widgets/notice/NoticeWidget.tsx
+++ b/src/widgets/notice/NoticeWidget.tsx
@@ -1,0 +1,42 @@
+import { View } from 'react-native';
+import NoticeCard, { Notice } from './NoticeCard';
+import NoticeHeader from './NoticeHeader';
+
+const MOCK_NOTICES: Notice[] = [
+    {
+    id: 1,
+    title: '[필독] 이번 주말 야간 근무자 유의사항',
+    content: '매장 청소 및 재고 확인 체크리스트를 반드시 확인해 주세요.',
+    createdAt: '2024-06-01T10:00:00Z',
+  },
+  {
+    id: 2,
+    title: '매장 청소 체크리스트 업데이트 안내',
+    content: '새로운 청소 구역이 추가되었습니다.',
+    createdAt: '2024-06-02T10:00:00Z',
+  },
+  {
+    id: 3,
+    title: '3월 급여 정산 관련 공지',
+    content: '급여 정산일이 공휴일인 관계로 하루 일찍 지급될 예정입니다.',
+    createdAt: '2024-06-03T10:00:00Z',
+  },
+];
+
+type NoticeWidgetProps = {
+  onPressHeader?: () => void;
+};
+
+
+export default function NoticeWidget({ onPressHeader }: NoticeWidgetProps ) {
+    return (
+        <View>
+            <NoticeHeader onPress={onPressHeader} />
+            {MOCK_NOTICES.map((notice)=>(
+                <NoticeCard
+                    key={notice.id}
+                    notice={notice}
+                />
+            ))}
+        </View>
+    )}


### PR DESCRIPTION
## **Description**

공지사항 API 연동 및 권한별 공지 관리 기능을 구현했습니다.

- 공지 목록/상세 조회 API 연결
- 공지 작성/수정/삭제 API 연결
- 공개/비공개 전환 기능 연결
- 공지 목록, 상세, 작성/수정 UI 반영
- 권한별 공지 조회/관리 분기 처리
- access token 만료 시 refresh token 재발급 요청 방식 수정

## More
Issue #23 
- 일반 알바생은 공개 공지만 조회할 수 있습니다.
- 매니저는 공개/비공개 공지를 모두 조회할 수 있습니다.
- 매니저 중 `canManageNotice` 권한이 있는 경우에만 작성/수정/삭제/공개전환이 가능합니다.
- 오너는 모든 공지 조회 및 관리 기능을 사용할 수 있습니다.
- 공지 삭제 시 확인 모달을 표시합니다.
- 공지 작성/수정 중 뒤로가기 시 작성 내용 삭제 안내 모달을 표시합니다.