### PR TITLE
Fix/#79

### DIFF
--- a/app/[storeId]/_layout.tsx
+++ b/app/[storeId]/_layout.tsx
@@ -81,7 +81,18 @@ export default function Layout() {
     <Tabs screenOptions={{ headerShown: false }}>
       <Tabs.Screen name="index" options={{ href: null }} />
       <Tabs.Screen name="home" options={{ title: '홈' }} />
-      <Tabs.Screen name="schedule" options={{ title: '스케줄' }} />
+      <Tabs.Screen
+        name="schedule"
+        options={{
+          title: '스케줄',
+          href: storeId
+            ? {
+                pathname: '/[storeId]/schedule',
+                params: { storeId },
+              }
+            : null,
+        }}
+      />
       <Tabs.Screen name="my" options={{ title: '마이' }} />
     </Tabs>
   );

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -17,11 +17,9 @@ export default function Layout() {
   const setUser = useUser((state) => state.setUser);
   const clearUser = useUser((state) => state.clearUser);
   const isAuthRoute = pathname.startsWith('/auth');
-  const [isBootstrapLoading, setIsBootstrapLoading] = useState(!isAuthRoute);
 
   useEffect(() => {
     if (isAuthRoute) {
-      setIsBootstrapLoading(false);
       void SplashScreen.hideAsync();
       return;
     }
@@ -43,14 +41,12 @@ export default function Layout() {
         await clearUser();
         router.replace('/auth');
       } finally {
-        setIsBootstrapLoading(false);
         void SplashScreen.hideAsync();
       }
     };
 
-    setIsBootstrapLoading(true);
     fetchUser();
-  }, [clearUser, isAuthRoute, router, setUser]);
+  }, [isAuthRoute, router]);
 
   useEffect(() => {
     const notificationSubscription =
@@ -97,10 +93,6 @@ export default function Layout() {
       responseSubscription.remove();
     };
   }, [router]);
-
-  if (isBootstrapLoading) {
-    return null;
-  }
 
   return <Stack screenOptions={{ headerShown: false }} />;
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,6 +1,7 @@
 import * as Notifications from 'expo-notifications';
 import { Stack, usePathname, useRouter } from 'expo-router';
-import { useEffect } from 'react';
+import * as SplashScreen from 'expo-splash-screen';
+import { useEffect, useState } from 'react';
 
 import { emitNotificationReceived } from '@/src/features/push/lib/notificationEvents';
 import { preparePushNotificationsAsync } from '@/src/features/push/lib/pushNotification';
@@ -8,14 +9,20 @@ import { getUserProfile } from '@/src/features/user/api/profile';
 import { navigateFromNotification } from '@/src/features/user/lib/notificationNavigation';
 import useUser from '@/src/features/user/lib/useUser';
 
+void SplashScreen.preventAutoHideAsync();
+
 export default function Layout() {
   const router = useRouter();
   const pathname = usePathname();
   const setUser = useUser((state) => state.setUser);
   const clearUser = useUser((state) => state.clearUser);
+  const isAuthRoute = pathname.startsWith('/auth');
+  const [isBootstrapLoading, setIsBootstrapLoading] = useState(!isAuthRoute);
 
   useEffect(() => {
-    if (pathname.startsWith('/auth')) {
+    if (isAuthRoute) {
+      setIsBootstrapLoading(false);
+      void SplashScreen.hideAsync();
       return;
     }
 
@@ -35,11 +42,15 @@ export default function Layout() {
       } catch (_) {
         await clearUser();
         router.replace('/auth');
+      } finally {
+        setIsBootstrapLoading(false);
+        void SplashScreen.hideAsync();
       }
     };
 
+    setIsBootstrapLoading(true);
     fetchUser();
-  }, [clearUser, pathname, router, setUser]);
+  }, [clearUser, isAuthRoute, router, setUser]);
 
   useEffect(() => {
     const notificationSubscription =
@@ -48,7 +59,9 @@ export default function Layout() {
 
         emitNotificationReceived({
           notificationId:
-            typeof data.notificationId === 'string' ? data.notificationId : null,
+            typeof data.notificationId === 'string'
+              ? data.notificationId
+              : null,
           storeId: typeof data.storeId === 'string' ? data.storeId : null,
           targetId: typeof data.targetId === 'string' ? data.targetId : null,
           type: typeof data.type === 'string' ? data.type : null,
@@ -84,6 +97,10 @@ export default function Layout() {
       responseSubscription.remove();
     };
   }, [router]);
+
+  if (isBootstrapLoading) {
+    return null;
+  }
 
   return <Stack screenOptions={{ headerShown: false }} />;
 }

--- a/app/auth/_layout.tsx
+++ b/app/auth/_layout.tsx
@@ -1,5 +1,5 @@
-import { Slot, Stack } from 'expo-router';
+import { Stack } from 'expo-router';
 
 export default function Layout() {
-  return <Slot />;
+  return <Stack screenOptions={{ headerShown: false }} />;
 }

--- a/src/features/store/lib/replaceToInitialRoute.ts
+++ b/src/features/store/lib/replaceToInitialRoute.ts
@@ -1,0 +1,21 @@
+import { getMyStore } from '@/src/features/store/api/store';
+
+type RouterLike = {
+  replace: (href: any) => void;
+};
+
+export async function replaceToInitialRoute(router: RouterLike) {
+  try {
+    const { data: myStores } = await getMyStore();
+    const firstStore = myStores[0];
+
+    if (!firstStore) {
+      router.replace('/store');
+      return;
+    }
+
+    router.replace(`/${firstStore.storeId}`);
+  } catch {
+    router.replace('/store');
+  }
+}

--- a/src/features/user/api/feedback.ts
+++ b/src/features/user/api/feedback.ts
@@ -1,18 +1,16 @@
 import axios from 'axios';
 
+import { apiClient } from '@/src/shared/api/api';
+
 const DISCORD_WEBHOOK_URL =
   'https://discord.com/api/webhooks/1509844668727164928/Kb5nXxC5D2gjJTIjNPiuRuQJg6SY2KRsPa3C_ta3kqmqCptRmHZXf-09lwHCc912Zdbe';
 
-export async function sendFeedback(feedback: string) {
-  return axios.post(
-    DISCORD_WEBHOOK_URL,
-    {
-      content: ['[의견보내기]', feedback].join('\n'),
-    },
-    {
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    },
-  );
+export async function sendFeedback({
+  title,
+  content,
+}: {
+  title: string;
+  content: string;
+}) {
+  return apiClient.post('/feedback', { title, content });
 }

--- a/src/features/user/api/notification.ts
+++ b/src/features/user/api/notification.ts
@@ -2,7 +2,10 @@ import { AxiosResponse } from 'axios';
 
 import { apiClient } from '@/src/shared/api/api';
 
-import NotificationResponse from '../model/notification';
+import NotificationResponse, {
+  NotificationSettingsRequest,
+  NotificationSettingsResponse,
+} from '../model/notification';
 
 export async function getNotifications(params: {
   storeId: string;
@@ -14,4 +17,15 @@ export async function getNotifications(params: {
 
 export async function readNotification(id: string) {
   return apiClient.patch(`/notifications/${id}/read`);
+}
+
+export async function getNotificationSettings(): Promise<
+  AxiosResponse<NotificationSettingsResponse>
+> {
+  return apiClient.get('/notifications/settings');
+}
+export async function setNotificationSettings(
+  data: NotificationSettingsRequest,
+): Promise<AxiosResponse<NotificationSettingsResponse>> {
+  return apiClient.patch('/notifications/settings', data);
 }

--- a/src/features/user/lib/notificationNavigation.ts
+++ b/src/features/user/lib/notificationNavigation.ts
@@ -49,8 +49,12 @@ function buildNotificationTarget(
       }
 
       return {
-        pathname: '/[storeId]/schedule/[scheduleId]',
-        params: { storeId, scheduleId: targetId },
+        pathname: '/[storeId]/schedule',
+        params: {
+          storeId,
+          openScheduleId: targetId,
+          openScheduleModal: 'true',
+        },
       };
     default:
       return null;

--- a/src/features/user/model/notification.ts
+++ b/src/features/user/model/notification.ts
@@ -10,3 +10,17 @@ export default interface NotificationResponse {
   isRead: boolean;
   createdAt: string; //'2026-07-02T11:04:52.930Z';
 }
+
+export interface NotificationSettingsResponse {
+  pushEnabled: boolean;
+  noticePushEnabled: boolean;
+  scheduleChangePushEnabled: boolean;
+  scheduleReminderPushEnabled: boolean;
+}
+
+export interface NotificationSettingsRequest {
+  pushEnabled: boolean;
+  noticePushEnabled: boolean;
+  scheduleChangePushEnabled: boolean;
+  scheduleReminderPushEnabled: boolean;
+}

--- a/src/pages/auth/AuthInfoPage.tsx
+++ b/src/pages/auth/AuthInfoPage.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
 
 import BirthDatePickerBottomSheet from '@/src/features/auth/ui/BirthDatePickerBottomSheet';
+import { replaceToInitialRoute } from '@/src/features/store/lib/replaceToInitialRoute';
 import {
   getUserProfile,
   updateUserProfile,
@@ -64,7 +65,7 @@ export default function AuthInfoPage() {
         birthDate: birthDate ? formatBirthDate(birthDate) : '',
       });
       setIsSubmittingSignUp(true);
-      router.replace('/');
+      await replaceToInitialRoute(router);
     } catch (error) {
       console.log(error);
       setIsSubmittingSignUp(false);

--- a/src/pages/auth/AuthVerifyPage.tsx
+++ b/src/pages/auth/AuthVerifyPage.tsx
@@ -5,6 +5,7 @@ import { Alert } from 'react-native';
 
 import { signUp } from '@/src/features/auth/api/sign';
 import { sendCode, verifyCode } from '@/src/features/auth/api/verify';
+import { replaceToInitialRoute } from '@/src/features/store/lib/replaceToInitialRoute';
 import BirthDatePickerBottomSheet from '@/src/features/auth/ui/BirthDatePickerBottomSheet';
 import ExistingEmailModal from '@/src/features/auth/ui/ExistingEmailModal';
 import VerificationCodeResendModal from '@/src/features/auth/ui/VerificationCodeResendModal';
@@ -69,7 +70,7 @@ export default function AuthVerifyPage() {
         ).padStart(2, '0')}`,
       });
 
-      router.replace('/');
+      await replaceToInitialRoute(router);
     } catch (error) {
       const status = isAxiosError(error) ? error.response?.status : undefined;
       const errorMessage = isAxiosError(error)

--- a/src/pages/auth/SignInPage.tsx
+++ b/src/pages/auth/SignInPage.tsx
@@ -10,6 +10,7 @@ import {
   saveAccessToken,
   saveRefreshToken,
 } from '@/src/features/auth/lib/storage';
+import { replaceToInitialRoute } from '@/src/features/store/lib/replaceToInitialRoute';
 import { basicColorGrey800 } from '@/src/init/styles/tokens';
 import BaseModal from '@/src/shared/ui/BaseModal';
 import Main from '@/src/shared/ui/Main';
@@ -92,7 +93,7 @@ export default function SignInPage() {
       await saveAccessToken(accessToken);
       await saveRefreshToken(refreshToken);
 
-      router.replace('/');
+      await replaceToInitialRoute(router);
     } catch (error) {
       const statusCode = isAxiosError(error)
         ? error.response?.status
@@ -150,9 +151,12 @@ export default function SignInPage() {
 
       await saveAccessToken(savedAccessToken);
       await saveRefreshToken(refreshToken);
-      router.replace(
-        shouldRedirectToAuthInfo(tokenPayload) ? '/auth/info' : '/',
-      );
+      if (shouldRedirectToAuthInfo(tokenPayload)) {
+        router.replace('/auth/info');
+        return;
+      }
+
+      await replaceToInitialRoute(router);
     } catch (error) {
       const errorMessage = isAxiosError(error)
         ? typeof error.response?.data === 'string'
@@ -203,9 +207,12 @@ export default function SignInPage() {
 
       await saveAccessToken(savedAccessToken);
       await saveRefreshToken(refreshToken);
-      router.replace(
-        shouldRedirectToAuthInfo(tokenPayload) ? '/auth/info' : '/',
-      );
+      if (shouldRedirectToAuthInfo(tokenPayload)) {
+        router.replace('/auth/info');
+        return;
+      }
+
+      await replaceToInitialRoute(router);
     } catch (error: any) {
       const errorMessage = isAxiosError(error)
         ? typeof error.response?.data === 'string'

--- a/src/pages/store/info/StoreInfoPage.tsx
+++ b/src/pages/store/info/StoreInfoPage.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/src/features/permission/lib/access';
 import useCurrentStoreAccess from '@/src/features/permission/lib/useCurrentStoreAccess';
 import { deleteStore, getStore } from '@/src/features/store/api/store';
+import { replaceToInitialRoute } from '@/src/features/store/lib/replaceToInitialRoute';
 import { spacingSpacing12, typoColorRed } from '@/src/init/styles/tokens';
 import BaseModal from '@/src/shared/ui/BaseModal';
 import NText from '@/src/shared/ui/NText';
@@ -48,7 +49,7 @@ export default function StoreInfoPage() {
   const handleDeleteStore = async () => {
     try {
       await deleteStore(storeId);
-      router.replace('/');
+      await replaceToInitialRoute(router);
     } catch {
     } finally {
       setDeleteModalStep('none');

--- a/src/pages/store/my/AlarmSettingPage.tsx
+++ b/src/pages/store/my/AlarmSettingPage.tsx
@@ -1,6 +1,10 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 
+import {
+  getNotificationSettings,
+  setNotificationSettings,
+} from '@/src/features/user/api/notification';
 import {
   backgroundColorWhite,
   radiusRadius12,
@@ -21,6 +25,71 @@ export default function AlarmSettingPage() {
 
   const isChildToggleDisabled = !isAlarmEnabled;
 
+  useEffect(() => {
+    const fetchNotificationSettings = async () => {
+      try {
+        const { data } = await getNotificationSettings();
+        setIsAlarmEnabled(data.pushEnabled);
+        setIsNoticeEnabled(data.noticePushEnabled);
+        setIsScheduleChangeEnabled(data.scheduleChangePushEnabled);
+        setIsWorkReminderEnabled(data.scheduleReminderPushEnabled);
+      } catch {}
+    };
+
+    fetchNotificationSettings();
+  }, []);
+
+  const updateNotificationSettings = async (nextSettings: {
+    pushEnabled: boolean;
+    noticePushEnabled: boolean;
+    scheduleChangePushEnabled: boolean;
+    scheduleReminderPushEnabled: boolean;
+  }) => {
+    try {
+      await setNotificationSettings(nextSettings);
+    } catch {}
+  };
+
+  const handleChangeAlarmEnabled = (value: boolean) => {
+    setIsAlarmEnabled(value);
+    updateNotificationSettings({
+      pushEnabled: value,
+      noticePushEnabled: isNoticeEnabled,
+      scheduleChangePushEnabled: isScheduleChangeEnabled,
+      scheduleReminderPushEnabled: isWorkReminderEnabled,
+    });
+  };
+
+  const handleChangeNoticeEnabled = (value: boolean) => {
+    setIsNoticeEnabled(value);
+    updateNotificationSettings({
+      pushEnabled: isAlarmEnabled,
+      noticePushEnabled: value,
+      scheduleChangePushEnabled: isScheduleChangeEnabled,
+      scheduleReminderPushEnabled: isWorkReminderEnabled,
+    });
+  };
+
+  const handleChangeScheduleChangeEnabled = (value: boolean) => {
+    setIsScheduleChangeEnabled(value);
+    updateNotificationSettings({
+      pushEnabled: isAlarmEnabled,
+      noticePushEnabled: isNoticeEnabled,
+      scheduleChangePushEnabled: value,
+      scheduleReminderPushEnabled: isWorkReminderEnabled,
+    });
+  };
+
+  const handleChangeWorkReminderEnabled = (value: boolean) => {
+    setIsWorkReminderEnabled(value);
+    updateNotificationSettings({
+      pushEnabled: isAlarmEnabled,
+      noticePushEnabled: isNoticeEnabled,
+      scheduleChangePushEnabled: isScheduleChangeEnabled,
+      scheduleReminderPushEnabled: value,
+    });
+  };
+
   return (
     <PageLayout title="알림 설정">
       <View style={[styles.card, { marginTop: spacingSpaicng14 }]}>
@@ -28,7 +97,10 @@ export default function AlarmSettingPage() {
           <NText variant="m14" style={styles.label}>
             알림
           </NText>
-          <Toggle value={isAlarmEnabled} onValueChange={setIsAlarmEnabled} />
+          <Toggle
+            value={isAlarmEnabled}
+            onValueChange={handleChangeAlarmEnabled}
+          />
         </View>
       </View>
       <View style={[styles.card, { marginTop: spacingSpacing30 }]}>
@@ -40,7 +112,7 @@ export default function AlarmSettingPage() {
             <Toggle
               value={!isChildToggleDisabled && isNoticeEnabled}
               disabled={isChildToggleDisabled}
-              onValueChange={setIsNoticeEnabled}
+              onValueChange={handleChangeNoticeEnabled}
             />
           </View>
         </View>
@@ -52,7 +124,7 @@ export default function AlarmSettingPage() {
             <Toggle
               value={!isChildToggleDisabled && isScheduleChangeEnabled}
               disabled={isChildToggleDisabled}
-              onValueChange={setIsScheduleChangeEnabled}
+              onValueChange={handleChangeScheduleChangeEnabled}
             />
           </View>
         </View>
@@ -64,7 +136,7 @@ export default function AlarmSettingPage() {
             <Toggle
               value={!isChildToggleDisabled && isWorkReminderEnabled}
               disabled={isChildToggleDisabled}
-              onValueChange={setIsWorkReminderEnabled}
+              onValueChange={handleChangeWorkReminderEnabled}
             />
           </View>
         </View>

--- a/src/pages/store/my/AlarmSettingPage.tsx
+++ b/src/pages/store/my/AlarmSettingPage.tsx
@@ -1,5 +1,91 @@
-import { View } from 'react-native';
+import { useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import {
+  backgroundColorWhite,
+  radiusRadius12,
+  spacingSpacing8,
+  spacingSpacing30,
+  spacingSpaicng14,
+  typoColorPrimary,
+} from '@/src/init/styles/tokens';
+import NText from '@/src/shared/ui/NText';
+import PageLayout from '@/src/shared/ui/PageLayout';
+import Toggle from '@/src/shared/ui/Toggle';
 
 export default function AlarmSettingPage() {
-  return <View />;
+  const [isAlarmEnabled, setIsAlarmEnabled] = useState(true);
+  const [isNoticeEnabled, setIsNoticeEnabled] = useState(true);
+  const [isScheduleChangeEnabled, setIsScheduleChangeEnabled] = useState(true);
+  const [isWorkReminderEnabled, setIsWorkReminderEnabled] = useState(true);
+
+  const isChildToggleDisabled = !isAlarmEnabled;
+
+  return (
+    <PageLayout title="알림 설정">
+      <View style={[styles.card, { marginTop: spacingSpaicng14 }]}>
+        <View style={styles.row}>
+          <NText variant="m14" style={styles.label}>
+            알림
+          </NText>
+          <Toggle value={isAlarmEnabled} onValueChange={setIsAlarmEnabled} />
+        </View>
+      </View>
+      <View style={[styles.card, { marginTop: spacingSpacing30 }]}>
+        <View style={styles.card}>
+          <View style={styles.row}>
+            <NText variant="m14" style={styles.label}>
+              공지 등록
+            </NText>
+            <Toggle
+              value={!isChildToggleDisabled && isNoticeEnabled}
+              disabled={isChildToggleDisabled}
+              onValueChange={setIsNoticeEnabled}
+            />
+          </View>
+        </View>
+        <View style={styles.card}>
+          <View style={styles.row}>
+            <NText variant="m14" style={styles.label}>
+              스케줄 변경
+            </NText>
+            <Toggle
+              value={!isChildToggleDisabled && isScheduleChangeEnabled}
+              disabled={isChildToggleDisabled}
+              onValueChange={setIsScheduleChangeEnabled}
+            />
+          </View>
+        </View>
+        <View style={styles.card}>
+          <View style={styles.row}>
+            <NText variant="m14" style={styles.label}>
+              근무 하루전
+            </NText>
+            <Toggle
+              value={!isChildToggleDisabled && isWorkReminderEnabled}
+              disabled={isChildToggleDisabled}
+              onValueChange={setIsWorkReminderEnabled}
+            />
+          </View>
+        </View>
+      </View>
+    </PageLayout>
+  );
 }
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: backgroundColorWhite,
+    borderRadius: radiusRadius12,
+    paddingHorizontal: spacingSpacing8,
+  },
+  row: {
+    height: 52,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  label: {
+    color: typoColorPrimary,
+    flexShrink: 1,
+  },
+});

--- a/src/pages/store/my/FeedbackPage.tsx
+++ b/src/pages/store/my/FeedbackPage.tsx
@@ -9,12 +9,18 @@ import NText from '@/src/shared/ui/NText';
 import PageLayout from '@/src/shared/ui/PageLayout';
 
 export default function FeedbackPage() {
+  const [title, setTitle] = useState('');
   const [feedback, setFeedback] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
   const [isExitModalVisible, setIsExitModalVisible] = useState(false);
   const [isSuccessModalVisible, setIsSuccessModalVisible] = useState(false);
 
   const handleChangeFeedback = (t: string) => {
     setFeedback(t);
+  };
+
+  const handleChangeTitle = (t: string) => {
+    setTitle(t);
   };
 
   const handlePressBack = () => {
@@ -28,15 +34,20 @@ export default function FeedbackPage() {
 
   const handlePressSubmit = async () => {
     const trimmedFeedback = feedback.trim();
-
+    if (isLoading) {
+      return;
+    }
     if (!trimmedFeedback) {
       return;
     }
 
     try {
-      await sendFeedback(trimmedFeedback);
-      setFeedback('');
+      setIsLoading(true);
+      await sendFeedback({ title, content: trimmedFeedback });
+      setFeedback((prev) => '');
+      setTitle((prev) => '');
       setIsSuccessModalVisible(true);
+      setIsLoading(false);
     } catch (error) {
       console.error('의견 전송 실패', error);
     }
@@ -54,6 +65,17 @@ export default function FeedbackPage() {
         onPressCheckIcon={handlePressSubmit}
         onPressBack={handlePressBack}
       >
+        <Input
+          variant=""
+          value={title}
+          onChangeText={handleChangeTitle}
+          multiline
+          placeholder="제목을 작성해주세요"
+          style={{
+            textAlignVertical: 'top',
+            marginTop: spacingSpaicng14,
+          }}
+        />
         <Input
           variant=""
           value={feedback}

--- a/src/pages/store/my/ProfileInfoPage.tsx
+++ b/src/pages/store/my/ProfileInfoPage.tsx
@@ -55,7 +55,7 @@ export default function ProfileInfoPage() {
       const { clearUser } = user;
       await clearUser();
 
-      router.replace('/');
+      router.replace('/auth');
     } catch {
     } finally {
       setIsDeleteAccountModalVisible(false);

--- a/src/pages/store/schedule/SchedulePage.tsx
+++ b/src/pages/store/schedule/SchedulePage.tsx
@@ -1,17 +1,17 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useIsFocused } from '@react-navigation/native';
 import { router, useLocalSearchParams } from 'expo-router';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 
 import { MemberRole } from '@/src/entities/member/member';
 import useCurrentStoreAccess from '@/src/features/permission/lib/useCurrentStoreAccess';
+import { getPositions } from '@/src/features/schedule/api/position';
 import {
   getDailySchedules,
   getMonthlySchedules,
   ScheduleScope,
 } from '@/src/features/schedule/api/schedule';
-import { getPositions } from '@/src/features/schedule/api/position';
 import useUser from '@/src/features/user/lib/useUser';
 import { buttonColorCta, typoColorPrimary } from '@/src/init/styles/tokens';
 import NText from '@/src/shared/ui/NText';
@@ -444,8 +444,15 @@ function normalizeStoreId(value?: string | string[]) {
 }
 
 export default function SchedulePage() {
-  const params = useLocalSearchParams<{ storeId?: string | string[] }>();
+  const params = useLocalSearchParams<{
+    storeId?: string | string[];
+    openScheduleId?: string | string[];
+    openScheduleModal?: string | string[];
+  }>();
   const routeStoreId = normalizeStoreId(params.storeId);
+  const notificationScheduleId = normalizeStoreId(params.openScheduleId);
+  const shouldOpenNotificationScheduleModal =
+    normalizeStoreId(params.openScheduleModal) === 'true';
   const currentStoreId = useUser((state) => state.currentStoreId);
   const userName = useUser((state) => state.name);
   const storeId = routeStoreId ?? currentStoreId ?? '';
@@ -481,6 +488,8 @@ export default function SchedulePage() {
   );
   const [positions, setPositions] = useState<SchedulePosition[]>([]);
   const [scheduleRefreshKey, setScheduleRefreshKey] = useState(0);
+  const [assignedSchedulesLoaded, setAssignedSchedulesLoaded] = useState(false);
+  const handledNotificationScheduleIdRef = useRef<string | null>(null);
   const canSelectAllView =
     workType === 'assigned' || canViewAllUnavailable;
 
@@ -536,6 +545,8 @@ export default function SchedulePage() {
     }
 
     const fetchMonthlySchedules = async () => {
+      setAssignedSchedulesLoaded(false);
+
       try {
         const { year, month } = parseMonth(currentMonth);
         const scope: ScheduleScope = viewType;
@@ -604,6 +615,8 @@ export default function SchedulePage() {
       } catch (error) {
         console.log('[schedule-monthly] failed', error);
         setAssignedSchedules([]);
+      } finally {
+        setAssignedSchedulesLoaded(true);
       }
     };
 
@@ -619,6 +632,47 @@ export default function SchedulePage() {
     userName,
     viewType,
     workType,
+  ]);
+
+  useEffect(() => {
+    if (!notificationScheduleId || !shouldOpenNotificationScheduleModal) {
+      handledNotificationScheduleIdRef.current = null;
+      return;
+    }
+
+    if (handledNotificationScheduleIdRef.current === notificationScheduleId) {
+      return;
+    }
+
+    if (
+      !storeId ||
+      !isFocused ||
+      !assignedSchedulesLoaded
+    ) {
+      return;
+    }
+
+    const targetSchedule = assignedSchedules.find(
+      (schedule) => schedule.id === notificationScheduleId,
+    );
+    handledNotificationScheduleIdRef.current = notificationScheduleId;
+
+    if (!targetSchedule) {
+      return;
+    }
+
+    setCurrentMonth(getMonthStart(targetSchedule.date));
+    setSelectedDate(targetSchedule.date);
+    setSelectedSchedule(targetSchedule);
+    setDateDetailVisible(false);
+    setFormVisible(true);
+  }, [
+    assignedSchedules,
+    assignedSchedulesLoaded,
+    isFocused,
+    notificationScheduleId,
+    shouldOpenNotificationScheduleModal,
+    storeId,
   ]);
 
   useEffect(() => {

--- a/src/shared/ui/BottomSheet.tsx
+++ b/src/shared/ui/BottomSheet.tsx
@@ -42,9 +42,12 @@ export default function BottomSheet({
       return;
     }
 
-    const showSubscription = Keyboard.addListener('keyboardDidShow', (event) => {
-      setKeyboardHeight(event.endCoordinates.height);
-    });
+    const showSubscription = Keyboard.addListener(
+      'keyboardDidShow',
+      (event) => {
+        setKeyboardHeight(event.endCoordinates.height);
+      },
+    );
     const hideSubscription = Keyboard.addListener('keyboardDidHide', () => {
       setKeyboardHeight(0);
     });
@@ -76,7 +79,7 @@ export default function BottomSheet({
     <Modal
       visible={visible}
       transparent
-      animationType="none"
+      animationType="slide"
       onRequestClose={onClose}
     >
       <View style={styles.overlay}>
@@ -86,7 +89,7 @@ export default function BottomSheet({
             styles.sheetContainer,
             Platform.OS === 'android' && { paddingBottom: keyboardHeight },
           ]}
-          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
         >
           <Animated.View
             style={[

--- a/src/widgets/schedule/ScheduleFormBottomSheet.tsx
+++ b/src/widgets/schedule/ScheduleFormBottomSheet.tsx
@@ -954,7 +954,7 @@ function ConfirmButton({ onPress }: { onPress: () => void }) {
 
 const styles = StyleSheet.create({
   sheet: {
-    maxHeight: '92%',
+    minHeight: 720,
     paddingHorizontal: 16,
     paddingTop: 8,
     paddingBottom: 32,

--- a/src/widgets/schedule/ScheduleFormBottomSheet.tsx
+++ b/src/widgets/schedule/ScheduleFormBottomSheet.tsx
@@ -535,6 +535,12 @@ export default function ScheduleFormBottomSheet({
       <ScheduleTimePickerBottomSheet
         visible={!!timePickerTarget}
         value={timePickerTarget === 'end' ? endTime : startTime}
+        minMinutes={
+          timePickerTarget === 'end' && startTime
+            ? Math.min(toTimeMinutes(startTime) + 60, 23 * 60 + 59)
+            : 0
+        }
+        maxMinutes={timePickerTarget === 'start' ? 22 * 60 + 59 : 23 * 60 + 59}
         onClose={() => setTimePickerTarget(null)}
         onChange={(nextTime) => {
           if (timePickerTarget === 'end') {
@@ -543,6 +549,11 @@ export default function ScheduleFormBottomSheet({
           }
 
           setStartTime(nextTime);
+          const nextEndTime = toTimeString(toTimeMinutes(nextTime) + 60);
+
+          if (!endTime || toTimeMinutes(endTime) < toTimeMinutes(nextTime) + 60) {
+            setEndTime(nextEndTime);
+          }
         }}
       />
       <BaseModal
@@ -656,6 +667,23 @@ export default function ScheduleFormBottomSheet({
 
 function formatDate(date: string) {
   return date.split('-').join('.');
+}
+
+function formatTime(hour: number, minute: number) {
+  return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+}
+
+function toTimeMinutes(value: string) {
+  const { hour, minute } = parseTime(value);
+  return hour * 60 + minute;
+}
+
+function toTimeString(totalMinutes: number) {
+  const clampedMinutes = Math.min(Math.max(totalMinutes, 0), 23 * 60 + 59);
+  const hour = Math.floor(clampedMinutes / 60);
+  const minute = clampedMinutes % 60;
+
+  return formatTime(hour, minute);
 }
 
 function InfoRow({
@@ -884,30 +912,67 @@ function parseTime(value: string) {
 function ScheduleTimePickerBottomSheet({
   visible,
   value,
+  minMinutes,
+  maxMinutes,
   onClose,
   onChange,
 }: {
   visible: boolean;
   value: string;
+  minMinutes?: number;
+  maxMinutes?: number;
   onClose: () => void;
   onChange: (value: string) => void;
 }) {
   const [draft, setDraft] = useState(parseTime(value));
-  const hours = createNumberRange(0, 23);
-  const minutes = createNumberRange(0, 59);
+  const resolvedMinMinutes = minMinutes ?? 0;
+  const resolvedMaxMinutes = maxMinutes ?? 23 * 60 + 59;
+  const minHour = Math.floor(resolvedMinMinutes / 60);
+  const maxHour = Math.floor(resolvedMaxMinutes / 60);
+  const hours = createNumberRange(minHour, maxHour);
+  const selectedTotalMinutes = draft.hour * 60 + draft.minute;
+  const clampedTotalMinutes = Math.min(
+    Math.max(selectedTotalMinutes, resolvedMinMinutes),
+    resolvedMaxMinutes,
+  );
+  const normalizedHour = Math.floor(clampedTotalMinutes / 60);
+  const normalizedMinute = clampedTotalMinutes % 60;
+  const minuteStart =
+    normalizedHour === minHour ? resolvedMinMinutes % 60 : 0;
+  const minuteEnd =
+    normalizedHour === maxHour ? resolvedMaxMinutes % 60 : 59;
+  const minutes = createNumberRange(minuteStart, minuteEnd);
 
   useEffect(() => {
     if (visible) {
-      setDraft(parseTime(value));
+      const totalMinutes = toTimeMinutes(value);
+      const nextMinutes = Math.min(
+        Math.max(totalMinutes, resolvedMinMinutes),
+        resolvedMaxMinutes,
+      );
+
+      setDraft({
+        hour: Math.floor(nextMinutes / 60),
+        minute: nextMinutes % 60,
+      });
     }
-  }, [value, visible]);
+  }, [resolvedMaxMinutes, resolvedMinMinutes, value, visible]);
+
+  useEffect(() => {
+    if (draft.hour !== normalizedHour || draft.minute !== normalizedMinute) {
+      setDraft({
+        hour: normalizedHour,
+        minute: normalizedMinute,
+      });
+    }
+  }, [draft.hour, draft.minute, normalizedHour, normalizedMinute]);
 
   return (
     <BottomSheet visible={visible} onClose={onClose} style={styles.wheelSheet}>
       <View style={styles.wheelRow}>
         <DateWheelColumn
           items={hours}
-          selectedValue={draft.hour}
+          selectedValue={normalizedHour}
           formatLabel={(hour) => `${hour}시`}
           onChange={(hour) =>
             setDraft((prev) => ({
@@ -918,7 +983,7 @@ function ScheduleTimePickerBottomSheet({
         />
         <DateWheelColumn
           items={minutes}
-          selectedValue={draft.minute}
+          selectedValue={normalizedMinute}
           formatLabel={(minute) => `${String(minute).padStart(2, '0')}분`}
           onChange={(minute) =>
             setDraft((prev) => ({
@@ -930,11 +995,7 @@ function ScheduleTimePickerBottomSheet({
       </View>
       <ConfirmButton
         onPress={() => {
-          onChange(
-            `${String(draft.hour).padStart(2, '0')}:${String(
-              draft.minute,
-            ).padStart(2, '0')}`,
-          );
+          onChange(formatTime(normalizedHour, normalizedMinute));
           onClose();
         }}
       />

--- a/src/widgets/schedule/ScheduleFormBottomSheet.tsx
+++ b/src/widgets/schedule/ScheduleFormBottomSheet.tsx
@@ -2,6 +2,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { isAxiosError } from 'axios';
 import { useEffect, useState } from 'react';
 import {
+  Modal,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -9,6 +10,7 @@ import {
   View,
 } from 'react-native';
 
+import { getMemberRoleLabel, MemberRole } from '@/src/entities/member/member';
 import DateWheelColumn from '@/src/features/auth/ui/DateWheelColumn';
 import {
   createSchedule,
@@ -16,7 +18,6 @@ import {
   updateSchedule,
 } from '@/src/features/schedule/api/schedule';
 import { getMembers } from '@/src/features/store/api/member';
-import { getMemberRoleLabel, MemberRole } from '@/src/entities/member/member';
 import {
   backgroundColorWhite,
   buttonColorCta,
@@ -36,6 +37,7 @@ import BaseModal from '@/src/shared/ui/BaseModal';
 import BottomSheet from '@/src/shared/ui/BottomSheet';
 import NText from '@/src/shared/ui/NText';
 
+import TitleButton from '../store/TitleButton';
 import {
   MOCK_MEMBERS,
   ScheduleItem,
@@ -99,8 +101,9 @@ export default function ScheduleFormBottomSheet({
   const isCreateMode = !schedule;
   const [isEditMode, setIsEditMode] = useState(false);
   const isFormMode = isCreateMode || isEditMode;
-  const [selectedMember, setSelectedMember] =
-    useState<ScheduleMember | null>(null);
+  const [selectedMember, setSelectedMember] = useState<ScheduleMember | null>(
+    null,
+  );
   const [selectedPosition, setSelectedPosition] =
     useState<SchedulePosition | null>(null);
   const [positionCleared, setPositionCleared] = useState(false);
@@ -117,33 +120,31 @@ export default function ScheduleFormBottomSheet({
   const [missingRequiredVisible, setMissingRequiredVisible] = useState(false);
   const [saveFailedVisible, setSaveFailedVisible] = useState(false);
   const [failedTitle, setFailedTitle] = useState('저장에 실패했어요');
-  const [saveErrorMessage, setSaveErrorMessage] = useState(
-    '근무 등록에 실패했어요',
-  );
+  const [saveErrorMessage, setSaveErrorMessage] =
+    useState('근무 등록에 실패했어요');
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [members, setMembers] = useState<ScheduleMember[]>(MOCK_MEMBERS);
-  const memberName =
-    selectedMember?.name ?? schedule?.memberName ?? '지정안됨';
-  const positionName =
-    positionCleared
-      ? '지정안됨'
-      : selectedPosition?.name ?? schedule?.positionName ?? '지정안됨';
+  const memberName = selectedMember?.name ?? schedule?.memberName ?? '지정안됨';
+  const positionName = positionCleared
+    ? '지정안됨'
+    : (selectedPosition?.name ?? schedule?.positionName ?? '지정안됨');
   const [startTime, setStartTime] = useState('');
   const [endTime, setEndTime] = useState('');
   const [selectedDate, setSelectedDate] = useState('');
   const [memo, setMemo] = useState('');
-  const displayDate = isFormMode ? selectedDate : schedule?.date ?? selectedDate;
+  const displayDate = isFormMode
+    ? selectedDate
+    : (schedule?.date ?? selectedDate);
   const scheduleMember = members.find(
     (member) =>
       member.id === schedule?.memberId || member.name === schedule?.memberName,
   );
   const selectedMemberId =
     selectedMember?.id ?? scheduleMember?.id ?? schedule?.memberId ?? null;
-  const selectedPositionId =
-    positionCleared
-      ? null
-      : selectedPosition?.id ?? schedule?.positionId ?? null;
+  const selectedPositionId = positionCleared
+    ? null
+    : (selectedPosition?.id ?? schedule?.positionId ?? null);
   const hasChanges =
     !!selectedMember ||
     !!selectedPosition ||
@@ -213,8 +214,8 @@ export default function ScheduleFormBottomSheet({
         memberId: selectedMember.id,
         memberName: selectedMember.name,
         positionId,
-        positionName: positionId ? selectedPosition?.name ?? null : null,
-        positionColor: positionId ? selectedPosition?.color ?? null : null,
+        positionName: positionId ? (selectedPosition?.name ?? null) : null,
+        positionColor: positionId ? (selectedPosition?.color ?? null) : null,
         startTime,
         endTime,
         memo,
@@ -250,7 +251,9 @@ export default function ScheduleFormBottomSheet({
         memberName,
         positionId,
         positionName: positionId ? positionName : null,
-        positionColor: positionId ? selectedPosition?.color ?? schedule.positionColor ?? null : null,
+        positionColor: positionId
+          ? (selectedPosition?.color ?? schedule.positionColor ?? null)
+          : null,
         startTime,
         endTime,
         memo,
@@ -368,7 +371,7 @@ export default function ScheduleFormBottomSheet({
         ) : (
           <Pressable
             style={styles.headerButton}
-            onPress={() => setMenuVisible((visible) => !visible)}
+            onPress={() => setMenuVisible((v) => !v)}
           >
             <Ionicons
               name="ellipsis-vertical"
@@ -436,17 +439,15 @@ export default function ScheduleFormBottomSheet({
           <NText variant="r12" style={styles.sectionTitle}>
             날짜
           </NText>
-          <TextInput
-            value={formatDate(displayDate)}
-            placeholder="YYYY.MM.DD"
-            placeholderTextColor={typoColorSub2}
-            editable={false}
-            onPressIn={() => {
+          <TitleButton
+            title={displayDate ? formatDate(displayDate) : 'YYYY.MM.DD'}
+            isPlaceholder={!displayDate}
+            showIcon={false}
+            onPress={() => {
               if (isFormMode) {
                 setDatePickerVisible(true);
               }
             }}
-            style={styles.input}
           />
         </View>
 
@@ -459,34 +460,30 @@ export default function ScheduleFormBottomSheet({
               <NText variant="r12" style={styles.timeLabel}>
                 시작
               </NText>
-              <TextInput
-                value={startTime}
-                placeholder="00:00"
-                placeholderTextColor={typoColorSub2}
-                editable={false}
-                onPressIn={() => {
+              <TitleButton
+                title={startTime ? startTime : '00:00'}
+                isPlaceholder={!startTime}
+                showIcon={false}
+                onPress={() => {
                   if (isFormMode) {
                     setTimePickerTarget('start');
                   }
                 }}
-                style={styles.input}
               />
             </View>
             <View style={styles.timeColumn}>
               <NText variant="r12" style={styles.timeLabel}>
                 종료
               </NText>
-              <TextInput
-                value={endTime}
-                placeholder="00:00"
-                placeholderTextColor={typoColorSub2}
-                editable={false}
-                onPressIn={() => {
+              <TitleButton
+                title={endTime ? endTime : '00:00'}
+                isPlaceholder={!endTime}
+                showIcon={false}
+                onPress={() => {
                   if (isFormMode) {
                     setTimePickerTarget('end');
                   }
                 }}
-                style={styles.input}
               />
             </View>
           </View>
@@ -567,7 +564,13 @@ export default function ScheduleFormBottomSheet({
           <BaseModal.Button
             onPress={isCreateMode ? handleCreateSchedule : handleUpdateSchedule}
           >
-            {saving ? (isCreateMode ? '추가중' : '수정중') : isCreateMode ? '추가하기' : '수정하기'}
+            {saving
+              ? isCreateMode
+                ? '추가중'
+                : '수정중'
+              : isCreateMode
+                ? '추가하기'
+                : '수정하기'}
           </BaseModal.Button>
         </BaseModal.Actions>
       </BaseModal>
@@ -734,11 +737,7 @@ function PositionPickerBottomSheet({
                 {position.name}
               </NText>
               {selected && (
-                <Ionicons
-                  name="checkmark"
-                  size={22}
-                  color={typoColorPrimary}
-                />
+                <Ionicons name="checkmark" size={22} color={typoColorPrimary} />
               )}
             </Pressable>
           );
@@ -783,11 +782,7 @@ function MemberPickerBottomSheet({
                 {member.roleName ? ` · ${member.roleName}` : ''}
               </NText>
               {selected && (
-                <Ionicons
-                  name="checkmark"
-                  size={22}
-                  color={typoColorPrimary}
-                />
+                <Ionicons name="checkmark" size={22} color={typoColorPrimary} />
               )}
             </Pressable>
           );

--- a/src/widgets/schedule/ScheduleFormBottomSheet.tsx
+++ b/src/widgets/schedule/ScheduleFormBottomSheet.tsx
@@ -551,7 +551,10 @@ export default function ScheduleFormBottomSheet({
           setStartTime(nextTime);
           const nextEndTime = toTimeString(toTimeMinutes(nextTime) + 60);
 
-          if (!endTime || toTimeMinutes(endTime) < toTimeMinutes(nextTime) + 60) {
+          if (
+            !endTime ||
+            toTimeMinutes(endTime) < toTimeMinutes(nextTime) + 60
+          ) {
             setEndTime(nextEndTime);
           }
         }}
@@ -937,10 +940,8 @@ function ScheduleTimePickerBottomSheet({
   );
   const normalizedHour = Math.floor(clampedTotalMinutes / 60);
   const normalizedMinute = clampedTotalMinutes % 60;
-  const minuteStart =
-    normalizedHour === minHour ? resolvedMinMinutes % 60 : 0;
-  const minuteEnd =
-    normalizedHour === maxHour ? resolvedMaxMinutes % 60 : 59;
+  const minuteStart = normalizedHour === minHour ? resolvedMinMinutes % 60 : 0;
+  const minuteEnd = normalizedHour === maxHour ? resolvedMaxMinutes % 60 : 59;
   const minutes = createNumberRange(minuteStart, minuteEnd);
 
   useEffect(() => {


### PR DESCRIPTION
## **Description**

로그인 부트스트랩 구간의 스플래시 처리, 안드로이드 스케줄 모달 동작 안정화, 알림 스케줄 라우팅 보정, 피드백 API 연동 수정, 알림 설정 페이지 구현을 포함한 업데이트입니다.

## 변경 사항
### 1. 로그인 여부 확인 중 스플래시 유지
- `app/_layout.tsx`에서 `expo-splash-screen`을 사용해 사용자 정보 확인이 끝날 때까지 스플래시를 유지하도록 변경했습니다.
- 인증 화면(`/auth`)에서는 즉시 스플래시를 종료하고, 그 외 경로에서는 프로필 조회 및 푸시 알림 준비가 끝난 뒤 화면을 렌더링하도록 정리했습니다.

### 2. 안드로이드 모달/스케줄 입력 UX 수정
- `BottomSheet`의 `Modal` 애니메이션 및 `KeyboardAvoidingView` 동작을 조정해 안드로이드에서 모달이 열리지 않던 문제를 수정했습니다.
- `ScheduleFormBottomSheet`에서 날짜/시간 입력 트리거를 정리하고, 모달 높이를 조정했습니다.
- 근무 시작/종료 시간 관계 유틸을 추가해:
  - 시작 시간 선택 시 종료 시간이 최소 1시간 뒤로 자동 보정되도록 했고
  - 종료 시간 선택 시 시작 시간 기준으로 선택 가능한 최소값이 제한되도록 했습니다.

### 3. 알림 탭 진입 시 스케줄 이동 로직 보정
- 스케줄 관련 알림 클릭 시 바로 상세 경로로 이동하던 흐름을 조정해, 스케줄 페이지로 이동한 뒤 대상 스케줄 모달을 열도록 변경했습니다.
- 삭제된 스케줄 알림은 계속 전체 스케줄 화면으로 이동하도록 유지했습니다.
- `SchedulePage`에서 알림 파라미터(`openScheduleId`, `openScheduleModal`)를 받아 목록 로딩 후 해당 스케줄을 자동으로 열도록 처리했습니다.

### 4. 피드백 전송 API 수정
- 기존 Discord Webhook 직접 호출 방식에서 앱 API(`/feedback`) 호출 방식으로 변경했습니다.
- 피드백 페이지에 제목 입력 필드를 추가하고, 제목/내용을 함께 전송하도록 수정했습니다.
- 중복 전송 방지를 위한 로딩 가드도 반영했습니다.

### 5. 알림 설정 페이지 구현
- 마이 페이지의 알림 설정 화면 UI를 구현했습니다.
- 상위 `알림` 토글 상태에 따라 하위 토글(`공지 등록`, `스케줄 변경`, `근무 하루전`)이 비활성화되도록 처리했습니다.

## More

> 코덱스한테 디스크립션 작성 요청함!
